### PR TITLE
[Front-End] feat: Popup 컴포넌트 추가

### DIFF
--- a/frontend/src/components/Popup/index.jsx
+++ b/frontend/src/components/Popup/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import * as S from './style';
+
+function Popup({ show, close, actions, children }) {
+  const actionButtons = actions.map((child, index) => {
+    const handleClick = () => {
+      if (child.onClick) {
+        child.onClick();
+      }
+      close();
+    };
+
+    if (child.secondary) {
+      return (
+        <S.SecondaryPopupButton key={index} onClick={handleClick}>
+          {child.text}
+        </S.SecondaryPopupButton>
+      );
+    }
+    return (
+      <S.PopupButton key={index} onClick={handleClick}>
+        {child.text}
+      </S.PopupButton>
+    );
+  });
+  return (
+    show && (
+      <>
+        <S.Overlay onClick={close} />
+        <S.Popup>
+          <S.PopupContent>{children}</S.PopupContent>
+          <S.PopupActions>{actionButtons}</S.PopupActions>
+        </S.Popup>
+      </>
+    )
+  );
+}
+
+export default Popup;

--- a/frontend/src/components/Popup/style.jsx
+++ b/frontend/src/components/Popup/style.jsx
@@ -1,0 +1,70 @@
+import styled, { css } from 'styled-components';
+import { FadeIn, FadeInWithTransform } from '../../styles/GlobalStyle';
+
+export const Overlay = styled.div`
+  ${FadeIn}
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 999;
+  width: 100%;
+  height: 100%;
+  background-color: #1f1f1fb2;
+  backdrop-filter: blur(6px);
+`;
+
+export const Popup = styled.div`
+  ${FadeInWithTransform}
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+  width: 335px;
+  height: 200px;
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.color.white};
+  overflow: hidden;
+`;
+
+export const PopupContent = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  padding: 20px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.color.black};
+`;
+
+export const PopupActions = styled.div`
+  display: flex;
+  justify-content: stretch;
+  align-items: center;
+  height: 52px;
+`;
+
+const PopupButtonStyles = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  font: ${({ theme }) => theme.font.headKR.Medium16};
+  user-select: none;
+`;
+
+export const SecondaryPopupButton = styled.button`
+  ${PopupButtonStyles}
+  background-color: ${({ theme }) => theme.color.gray['300']};
+  color: ${({ theme }) => theme.color.white};
+`;
+
+export const PopupButton = styled.button`
+  ${PopupButtonStyles}
+  background-color: ${({ theme }) => theme.color.primary['700']};
+  color: ${({ theme }) => theme.color.gray['100']};
+`;

--- a/frontend/src/styles/GlobalStyle.jsx
+++ b/frontend/src/styles/GlobalStyle.jsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css, keyframes } from 'styled-components';
 
 import HyundaiSansHeadBold from '../../assets/fonts/HyundaiSansHead-Bold.woff2';
 import HyundaiSansHeadKRBold from '../../assets/fonts/HyundaiSansHeadKROTFBold.woff2';
@@ -88,6 +88,30 @@ const GlobalStyle = createGlobalStyle`
   p, h1, h2, h3, h4, h5, h6 {
     margin: 0;
   }
+`;
+
+const fadeInWithTransformAnimation = keyframes`
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -45%);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+`;
+
+const fadeInAnimation = keyframes`
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+`;
+
+export const FadeInWithTransform = css`
+  animation: ${fadeInWithTransformAnimation} 0.25s ease-out forwards;
+`;
+
+export const FadeIn = css`
+  animation: ${fadeInAnimation} 0.25s ease-out forwards;
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
Close #82 

사용 예시 (전체 페이지):
``` js
function PopupTestPage() {
  const [show, setShow] = useState(false);
  const handleClose = () => setShow(false);
  const actions = [
    { secondary: true, text: '취소' },
    { text: '확인', onClick: () => alert('확인') },
  ];

  return (
    <div style={{ padding: '100px' }}>
      <button onClick={() => setShow(true)}>팝업 띄우는 버튼</button>
      <Popup show={show} close={handleClose} actions={actions}>
        Sample Popup
      </Popup>
    </div>
  );
}
```

사용 예시 (팝업 컴포넌트만):
``` js
<Popup show={show} close={handleClose} actions={actions}>
  Sample Popup
</Popup>
```

`show`: 팝업 표시 여부
`close`: 팝업 닫는 함수
`actions`: 팝업 하단에 표시될 액션 정보
`children`: 팝업에 표시될 메시지