### PR TITLE
[Front-End] Fe feature/#96

### DIFF
--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import * as S from './style';
+
+const palisadeUrl = 'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade';
+const trimSelect = 'le-blanc';
+const exteriorSelect = 'A2B';
+
+function TrimImage({ trim }) {
+  const [start, setStart] = useState(false);
+  const [image, setImage] = useState(1);
+  const [prevX, setPrevX] = useState(0);
+
+  const startSwipe = (event) => {
+    if (start) {
+      setPrevX(event.clientX);
+      //   console.log(prevX, event.clientX);
+      if (prevX < event.clientX) {
+        if (1 >= image) setImage(60);
+        else setImage((prevImage) => prevImage - 1);
+      }
+      if (prevX > event.clientX) {
+        if (60 <= image) setImage(1);
+        else setImage((prevImage) => prevImage + 1);
+      }
+    }
+  };
+  return (
+    <S.TrimImage>
+      <S.Image
+        src={`${palisadeUrl}/${trimSelect}/exterior/${exteriorSelect}/${image
+          .toString()
+          .padStart(3, '0')}.png`}
+        onMouseDown={() => setStart(true)}
+        onMouseUp={() => setStart(false)}
+        onMouseMove={startSwipe}
+      />
+    </S.TrimImage>
+  );
+}
+
+export default TrimImage;

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
@@ -23,7 +23,6 @@ function TrimImage({ trim, start }) {
     }
   };
 
-  console.log(start);
   return (
     <S.TrimImage>
       <S.Image

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
@@ -5,15 +5,13 @@ const palisadeUrl = 'https://want-car-image.s3.ap-northeast-2.amazonaws.com/pali
 const trimSelect = 'le-blanc';
 const exteriorSelect = 'A2B';
 
-function TrimImage({ trim }) {
-  const [start, setStart] = useState(false);
+function TrimImage({ trim, start }) {
   const [image, setImage] = useState(1);
   const [prevX, setPrevX] = useState(0);
 
   const startSwipe = (event) => {
     if (start) {
       setPrevX(event.clientX);
-      //   console.log(prevX, event.clientX);
       if (prevX < event.clientX) {
         if (1 >= image) setImage(60);
         else setImage((prevImage) => prevImage - 1);
@@ -24,14 +22,14 @@ function TrimImage({ trim }) {
       }
     }
   };
+
+  console.log(start);
   return (
     <S.TrimImage>
       <S.Image
         src={`${palisadeUrl}/${trimSelect}/exterior/${exteriorSelect}/${image
           .toString()
           .padStart(3, '0')}.png`}
-        onMouseDown={() => setStart(true)}
-        onMouseUp={() => setStart(false)}
         onMouseMove={startSwipe}
       />
     </S.TrimImage>

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/style.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/style.jsx
@@ -1,0 +1,13 @@
+import { styled } from 'styled-components';
+
+export const TrimImage = styled.div`
+  display: flex;
+  width: 592px;
+  height: 325px;
+  margin-top: 36px;
+  margin-left: 65px;
+`;
+
+export const Image = styled.img`
+  -webkit-user-drag: none;
+`;

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/style.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/style.jsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components';
 
 export const TrimImage = styled.div`
+  position: relative;
   display: flex;
   width: 592px;
   height: 325px;

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimStand/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimStand/index.jsx
@@ -1,0 +1,11 @@
+import * as S from './style';
+
+function TrimStand() {
+  return (
+    <S.TrimStand>
+      <S.Stand>360°</S.Stand>
+    </S.TrimStand>
+  );
+}
+
+export default TrimStand;

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimStand/style.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimStand/style.jsx
@@ -1,0 +1,25 @@
+import { styled } from 'styled-components';
+
+export const TrimStand = styled.div`
+  position: absolute;
+  width: 611px;
+  height: 102px;
+  margin-top: 228px;
+  margin-left: 210px;
+  border-radius: 50%;
+
+  border: 2px solid transparent;
+  background:
+    linear-gradient(#f4f5f7, #f4f5f7) padding-box,
+    linear-gradient(to top, #6d7786, transparent 90%) border-box;
+`;
+
+export const Stand = styled.div`
+  position: absolute;
+  display: flex;
+  padding: 14px;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  background-color: ${({ theme }) => theme.color.blueBG};
+`;

--- a/frontend/src/pages/ExteriorColorPage/Info/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/index.jsx
@@ -1,5 +1,6 @@
 import * as S from './style';
 import Title from '../../../components/Title';
+import TrimImage from './TrimImage';
 
 const TYPE = 'dark';
 const SUB_TITLE = '외장색상';
@@ -15,6 +16,7 @@ function Info() {
   return (
     <S.Info>
       <Title {...TitleProps} />
+      <TrimImage />
     </S.Info>
   );
 }

--- a/frontend/src/pages/ExteriorColorPage/Info/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/index.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import * as S from './style';
 import Title from '../../../components/Title';
 import TrimImage from './TrimImage';
+import TrimStand from './TrimStand';
 
 const TYPE = 'dark';
 const SUB_TITLE = '외장색상';
@@ -21,6 +22,7 @@ function Info() {
   return (
     <S.Info onMouseDown={() => setStart(true)}>
       <Title {...TitleProps} />
+      <TrimStand />
       <TrimImage {...TrimImageProps} />
     </S.Info>
   );

--- a/frontend/src/pages/ExteriorColorPage/Info/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/index.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import * as S from './style';
 import Title from '../../../components/Title';
 import TrimImage from './TrimImage';
@@ -7,6 +8,10 @@ const SUB_TITLE = '외장색상';
 const MAIN_TITLE = '어비스블랙펄';
 
 function Info() {
+  const [start, setStart] = useState(false);
+  document.addEventListener('mouseup', () => setStart(false));
+
+  const TrimImageProps = { start };
   const TitleProps = {
     type: TYPE,
     subTitle: SUB_TITLE,
@@ -14,9 +19,9 @@ function Info() {
   };
 
   return (
-    <S.Info>
+    <S.Info onMouseDown={() => setStart(true)}>
       <Title {...TitleProps} />
-      <TrimImage />
+      <TrimImage {...TrimImageProps} />
     </S.Info>
   );
 }


### PR DESCRIPTION
⚠️ border-image랑 border-radius는 같이 설정되지 않는다.

#### 해결방법
```
.btn-gradient-2 {
  background: linear-gradient(white, white) padding-box,
              linear-gradient(to right, darkblue, darkorchid) border-box;
  border-radius: 50em;
  border: 4px solid transparent;
}
```
border-radius 속성과 background 속성을 사용해서 대체하는 방법
선형 그래디언트 뒤에 지정된 'padding-box' 및 'border-box' 값은 배경을 나타낸다.

첫 번째 padding-box는 가짜 배경으로, border처럼 보이게 해준다.
두 번째 border-box는 border영역의 색을 나타내준다.
마지막으로 border에 transparent를 설정해서 border영역의 배경을 보이도록 해준다.

close #96 