### PR TITLE
[Backend] Swagger를 통해 API 목록을 볼 수 있도록 수정

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/config/SwaggerConfig.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ public class SwaggerConfig {
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("softeer.wantcar.cartalog.controller"))
+                .apis(RequestHandlerSelectors.basePackage("softeer.wantcar.cartalog"))
                 .paths(PathSelectors.any())
                 .build()
                 .apiInfo(apiInfo());


### PR DESCRIPTION
Swagger를 통해 API 목록 및 명세를 보지 못하던 버그 해결

resolve: #125 