### PR TITLE
[Front-End] feat: 옵션 선택 페이지 추가

### DIFF
--- a/frontend/src/components/RoundButton/style.jsx
+++ b/frontend/src/components/RoundButton/style.jsx
@@ -50,8 +50,10 @@ export const Title = styled.div`
       if (type === 'price' && $state === 'active') {
         return `background-color: ${theme.color.skyBlue}4c`;
       }
-      if (type === 'option' && $state === 'active') {
-        return `background-color: ${theme.color.white}`;
+      if (type === 'option') {
+        return `border: 1px solid ${theme.color.skyBlue};
+        color: ${theme.color.primary['500']};
+        `;
       }
     }}
   }

--- a/frontend/src/pages/OptionPickerPage/Info/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/Info/index.jsx
@@ -2,14 +2,23 @@ import * as S from './style';
 import Title from '../../../components/Title';
 
 const TYPE = 'dark';
-const SUB_TITLE = '파워트레인';
-const MAIN_TITLE = '컴포트 ll';
 
-function Info({ imageUrl }) {
+function mockInfo(id) {
+  return {
+    category: '파워트레인',
+    name: `옵션이름${id}`,
+    description:
+      '시동이 걸린 상태에서 해당 좌석의 통풍 스위치를 누르면 표시등이 켜지면서 해당 좌석에 바람이 나오는 편의장치입니다.',
+  };
+}
+
+function Info({ imageUrl, data, selected }) {
+  const mockData = mockInfo(selected);
   const TitleProps = {
     type: TYPE,
-    subTitle: SUB_TITLE,
-    mainTitle: MAIN_TITLE,
+    subTitle: mockData.category,
+    mainTitle: mockData.name,
+    description: mockData.description,
   };
 
   return (
@@ -17,7 +26,6 @@ function Info({ imageUrl }) {
       <S.ModelText>
         <Title {...TitleProps} />
       </S.ModelText>
-
       <S.ModelImage src={imageUrl} />
     </S.Info>
   );

--- a/frontend/src/pages/OptionPickerPage/Pick/CategorySelector/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/CategorySelector/index.jsx
@@ -1,0 +1,15 @@
+import RoundButton from '../../../../components/RoundButton';
+import * as S from './style';
+
+function CategorySelector({ data }) {
+  return (
+    <S.CategorySelector>
+      <RoundButton type="option" state="active" title="전체" />
+      {data.map((category) => (
+        <RoundButton key={category} type="option" state="inactive" title={category} />
+      ))}
+    </S.CategorySelector>
+  );
+}
+
+export default CategorySelector;

--- a/frontend/src/pages/OptionPickerPage/Pick/CategorySelector/style.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/CategorySelector/style.jsx
@@ -1,0 +1,6 @@
+import { styled } from 'styled-components';
+
+export const CategorySelector = styled.div`
+  display: flex;
+  gap: 8px;
+`;

--- a/frontend/src/pages/OptionPickerPage/Pick/TypeSelector/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/TypeSelector/index.jsx
@@ -1,0 +1,24 @@
+import * as S from './style';
+
+function TypeSelector({ showDefault, setShowDefault }) {
+  const handleClick = (value) => {
+    if (showDefault === value) return;
+    setShowDefault(value);
+  };
+
+  return (
+    <S.TypeSelector>
+      <S.SelectorItem
+        className={showDefault ? null : 'selected'}
+        onClick={() => handleClick(false)}
+      >
+        추가옵션
+      </S.SelectorItem>
+      <S.SelectorItem className={showDefault ? 'selected' : null} onClick={() => handleClick(true)}>
+        기본옵션
+      </S.SelectorItem>
+    </S.TypeSelector>
+  );
+}
+
+export default TypeSelector;

--- a/frontend/src/pages/OptionPickerPage/Pick/TypeSelector/style.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/TypeSelector/style.jsx
@@ -1,0 +1,15 @@
+import { styled } from 'styled-components';
+
+export const TypeSelector = styled.nav`
+  display: flex;
+  gap: 24px;
+`;
+
+export const SelectorItem = styled.button`
+  font: ${({ theme }) => theme.font.headKR.Medium16};
+  color: ${({ theme }) => theme.color.gray['200']};
+
+  &.selected {
+    color: ${({ theme }) => theme.color.gray['900']};
+  }
+`;

--- a/frontend/src/pages/OptionPickerPage/Pick/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/index.jsx
@@ -1,9 +1,55 @@
+import { useState } from 'react';
 import * as S from './style';
+import TypeSelector from './TypeSelector';
+import CategorySelector from './CategorySelector';
+import OptionCard from '../OptionCard';
 import NextButton from '../../../components/NextButton';
 
-function Pick() {
+const MOCK_CATEGORY = ['상세품목', '액세서리', '휠'];
+
+function initData(data) {
+  const result = {};
+
+  data.forEach((item) => {
+    result[item] = false;
+  });
+  return result;
+}
+
+function Pick({ data, selected, setSelected }) {
+  const [showDefault, setShowDefault] = useState(false);
+  const options = showDefault ? data.defaultOptions : data.selectOptions;
+  const [selectedOptions, setSelectedOptions] = useState(initData(options));
+
+  function handleSelect(id) {
+    setSelected(id);
+  }
+  function handleCheck(id) {
+    setSelectedOptions((prev) => ({ ...prev, [id]: !prev[id] }));
+  }
+
   return (
     <S.Pick>
+      <TypeSelector showDefault={showDefault} setShowDefault={setShowDefault} />
+      <CategorySelector data={MOCK_CATEGORY} />
+      <S.OptionGrid>
+        {options.map((option) => (
+          <OptionCard
+            key={option.id}
+            name={option.name}
+            pickRatio={option.chosen}
+            hashtags={option.hashTags}
+            price={option.price}
+            imgSrc={option.imageUrl}
+            hasHmgData
+            selected={selected === option.id}
+            checked={selectedOptions[option.id]}
+            select={() => handleSelect(option.id)}
+            check={() => handleCheck(option.id)}
+            isDefault={showDefault}
+          />
+        ))}
+      </S.OptionGrid>
       <S.Footer>
         <S.FooterEnd>
           <NextButton />

--- a/frontend/src/pages/OptionPickerPage/Pick/style.jsx
+++ b/frontend/src/pages/OptionPickerPage/Pick/style.jsx
@@ -1,6 +1,17 @@
 import styled from 'styled-components';
 
-export const Pick = styled.div``;
+export const Pick = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+`;
+
+export const OptionGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+`;
 
 export const Footer = styled.div`
   display: flex;

--- a/frontend/src/pages/OptionPickerPage/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/index.jsx
@@ -1,36 +1,74 @@
-import { useEffect, useState } from 'react';
-import { useData } from '../../utils/Context';
+import { useState } from 'react';
 import Section from '../../components/Section';
 import Info from './Info';
 import Pick from './Pick';
 
-const TYPE = 'AddOption';
+const TYPE = 'OptionPicker';
 const IMAGE_URL = '../../../../../assets/images/TrimSelect/interior.png';
 
-function OptionPicker() {
-  const [isFetched, setIsFetched] = useState(false);
-  const { setTrimState } = useData();
+const MOCK_DATA = {
+  multipleSelectParentCategory: ['상세 품목', '악세사리'],
+  selectOptions: [
+    {
+      id: 11,
+      name: '2열 통풍시트',
+      parentCategory: '상세품목',
+      childCategory: '시트',
+      imageUrl:
+        'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/alconbreak_s.jpg',
+      price: 350000,
+      chosen: 38,
+      hashTags: ['장거리 운전', '쾌적'],
+    },
+    {
+      id: 12,
+      name: '운전석 전동시트',
+      parentCategory: '상세품목',
+      childCategory: '시트',
+      imageUrl:
+        'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/10_driverseat_s.jpg',
+      price: 350000,
+      chosen: 38,
+      hashTags: ['장거리 운전', '쾌적'],
+    },
+    {
+      id: 13,
+      name: '좋아보이는 브레이크',
+      parentCategory: '상세품목',
+      childCategory: '휠',
+      imageUrl:
+        'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/alconbreak_s.jpg',
+      price: 350000,
+      chosen: 38,
+      hashTags: ['장거리 운전', '쾌적'],
+    },
+  ],
+  defaultOptions: [
+    {
+      id: 5,
+      name: '디젤 2.2 엔진',
+      parentCategory: null,
+      childCategory: '파워트레인/성능',
+      imageUrl:
+        'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/dieselengine2.2_s.jpg',
+      price: 0,
+      chosen: 38,
+      hashTags: ['장거리 운전'],
+    },
+  ],
+};
 
-  useEffect(() => {
-    async function fetchData() {
-      // !FIX API 데이터 받아오도록 수정해야함
-      setTrimState((prevState) => ({
-        ...prevState,
-        page: 5,
-      }));
-      setIsFetched(true);
-    }
-    fetchData();
-  }, []);
+function OptionPicker() {
+  const [selectedId, setSelectedId] = useState(11);
 
   const InfoProps = { imageUrl: IMAGE_URL };
   const SectionProps = {
     type: TYPE,
-    Info: <Info {...InfoProps} />,
-    Pick: <Pick />,
+    Info: <Info {...InfoProps} data={MOCK_DATA} selected={selectedId} />,
+    Pick: <Pick data={MOCK_DATA} selected={selectedId} setSelected={setSelectedId} />,
   };
 
-  return isFetched ? <Section {...SectionProps} /> : <>Loding...</>;
+  return <Section {...SectionProps} />;
 }
 
 export default OptionPicker;


### PR DESCRIPTION
# 설명

옵션 선택 페이지 레이아웃 추가

# 변경 사항

* Mock data 이용해서 데이터 표시
* 페이지 내 state 이용해서 선택한 옵션 데이터 처리

# Todo

* API 연결
* 카테고리 버튼 동작하도록 수정
* context api를 이용해서 다른 페이지로 상태 전달

# Related Issues

* close #215