### PR TITLE
[Front-End] 외장색상 API 수정 & 360도 수정 & Nav 수정

### DIFF
--- a/frontend/src/components/Header/Nav/index.jsx
+++ b/frontend/src/components/Header/Nav/index.jsx
@@ -1,11 +1,26 @@
 import { Link } from 'react-router-dom';
 import { useData } from '../../../utils/Context';
 import { NAV } from '../constants';
-import NavToggle from '../../NavToggle';
 import * as S from './style';
+import NavToggle from '../../NavToggle';
+
+function isLinkEnabled(item, modelType, exteriorColor, interiorColor, optionPicker) {
+  switch (item.to) {
+    case '/modelType':
+      return modelType.isFetch;
+    case '/exteriorColor':
+      return exteriorColor.isFetch;
+    case '/interiorColor':
+      return interiorColor.isFetch;
+    case '/optionPicker':
+      return optionPicker.isFetch;
+    default:
+      return true;
+  }
+}
 
 function Nav() {
-  const { page } = useData();
+  const { page, modelType, exteriorColor, interiorColor, optionPicker } = useData();
 
   return (
     <S.Nav>
@@ -13,7 +28,11 @@ function Nav() {
         {NAV.map((item) => (
           <S.Step key={item.label}>
             <S.Text className={item.page === page ? 'selected' : null}>
-              <Link to={item.to}>{item.label}</Link>
+              {isLinkEnabled(item, modelType, exteriorColor, interiorColor, optionPicker) ? (
+                <Link to={item.to}>{item.label}</Link>
+              ) : (
+                <span>{item.label}</span>
+              )}
             </S.Text>
             <S.Bar>
               <NavToggle selected={item.page === page} />

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
@@ -2,10 +2,6 @@ import { useState } from 'react';
 import { useData } from '../../../../utils/Context';
 import * as S from './style';
 
-// !FIX : API완성되면 상수 없애기
-const mockData =
-  'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/exterior/A2B';
-
 function TrimImage() {
   const { exteriorColor } = useData();
   const [image, setImage] = useState(1);
@@ -28,7 +24,7 @@ function TrimImage() {
   return (
     <S.TrimImage>
       <S.RotateImage
-        src={`${mockData}/${image.toString().padStart(3, '0')}.png`}
+        src={`${exteriorColor.carImageDirectory}${image.toString().padStart(3, '0')}.png`}
         onMouseMove={startSwipe}
       />
     </S.TrimImage>

--- a/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Info/TrimImage/index.jsx
@@ -4,7 +4,7 @@ import * as S from './style';
 
 function TrimImage() {
   const { exteriorColor } = useData();
-  const [image, setImage] = useState(1);
+  const [count, setCount] = useState(0);
   const [prevX, setPrevX] = useState(0);
 
   const startSwipe = (event) => {
@@ -14,19 +14,23 @@ function TrimImage() {
     setPrevX(currentX);
 
     if (diffX > 0) {
-      setImage((prevImage) => (prevImage === 1 ? 60 : prevImage - 1));
+      setCount((prevImage) => (prevImage === 0 ? 59 : prevImage - 1));
     }
     if (diffX < 0) {
-      setImage((prevImage) => (prevImage === 60 ? 1 : prevImage + 1));
+      setCount((prevImage) => (prevImage === 59 ? 0 : prevImage + 1));
     }
   };
 
   return (
     <S.TrimImage>
-      <S.RotateImage
-        src={`${exteriorColor.carImageDirectory}${image.toString().padStart(3, '0')}.png`}
-        onMouseMove={startSwipe}
-      />
+      {exteriorColor.carImageList.map((imagePath, index) => (
+        <S.RotateImage
+          key={imagePath}
+          src={imagePath}
+          style={{ display: index === count ? 'block' : 'none' }}
+          onMouseMove={startSwipe}
+        />
+      ))}
     </S.TrimImage>
   );
 }

--- a/frontend/src/pages/ExteriorColorPage/Pick/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/Pick/index.jsx
@@ -19,7 +19,11 @@ function Pick() {
         ...prevState.exteriorColor,
         code: exterior.code,
         name: exterior.name,
-        carImageUrl: exterior.carImageUrl,
+        carImageDirectory: exterior.carImageDirectory,
+        carImageList: Array.from({ length: 60 }, (_, index) => {
+          const imageNumber = (index + 1).toString().padStart(3, '0');
+          return `${exterior.carImageDirectory}${imageNumber}.png`;
+        }),
       },
       price: {
         ...prevState.price,

--- a/frontend/src/pages/ExteriorColorPage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/index.jsx
@@ -28,6 +28,10 @@ function ExteriorColor() {
             isFetch: true,
             name: defaultData.name,
             carImageDirectory: defaultData.carImageDirectory,
+            carImageList: Array.from({ length: 60 }, (_, index) => {
+              const imageNumber = (index + 1).toString().padStart(3, '0');
+              return `${defaultData.carImageDirectory}${imageNumber}.png`;
+            }),
           },
         }));
       }

--- a/frontend/src/pages/ExteriorColorPage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/index.jsx
@@ -27,7 +27,7 @@ function ExteriorColor() {
             page: dataFetch.exteriorColors.length - 3,
             isFetch: true,
             name: defaultData.name,
-            carImageUrl: defaultData.carImageUrl,
+            carImageDirectory: defaultData.carImageDirectory,
           },
         }));
       }

--- a/frontend/src/utils/Context/index.jsx
+++ b/frontend/src/utils/Context/index.jsx
@@ -55,7 +55,7 @@ export function StateProvider({ children }) {
           isFetch: false,
           code: null,
           name: null,
-          carImageUrl: null,
+          carImageDirectory: null,
           count: 1,
           page: null,
           position: null,

--- a/frontend/src/utils/Context/index.jsx
+++ b/frontend/src/utils/Context/index.jsx
@@ -56,6 +56,7 @@ export function StateProvider({ children }) {
           code: null,
           name: null,
           carImageDirectory: null,
+          carImageList: [],
           count: 1,
           page: null,
           position: null,

--- a/frontend/src/utils/Context/index.jsx
+++ b/frontend/src/utils/Context/index.jsx
@@ -65,7 +65,19 @@ export function StateProvider({ children }) {
         break;
       case 'interiorColor':
         acc[key] = {
-          dataFetch: [],
+          fetchData: [],
+          isFetch: false,
+          interiorColorId: 'I49',
+          pick: 'A22',
+          pickName: '퀼팅천연(블랙)',
+          pickCarImageUrl:
+            'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/10_driverseat_s.jpg',
+        };
+        break;
+      case 'optionPicker':
+        acc[key] = {
+          fetchData: [],
+          isFetch: false,
           interiorColorId: 'I49',
           pick: 'A22',
           pickName: '퀼팅천연(블랙)',


### PR DESCRIPTION
## 외장색상 API 수정
새로 수정된 API로 반영 🐌
```jsx
setTrimState((prevState) => ({
          ...prevState,
          exteriorColor: {
            ...exteriorColor,
            fetchData: [...dataFetch.exteriorColors],
            page: dataFetch.exteriorColors.length - 3,
            isFetch: true,
            name: defaultData.name,
            carImageDirectory: defaultData.carImageDirectory,
            carImageList: Array.from({ length: 60 }, (_, index) => {
              const imageNumber = (index + 1).toString().padStart(3, '0');
              return `${defaultData.carImageDirectory}${imageNumber}.png`;
            }),
          },
        }));
```
`carImageList`에는 미리 60개의 자동차 이미지를 받아놓음

```jsx
return (
    <S.TrimImage>
      {exteriorColor.carImageList.map((imagePath, index) => (
        <S.RotateImage
          key={imagePath}
          src={imagePath}
          style={{ display: index === count ? 'block' : 'none' }}
          onMouseMove={startSwipe}
        />
      ))}
    </S.TrimImage>
  );
```
`display:none`으로 이미지 미리 화면에 받아놓는 방식으로 수정

## Nav 수정
```jsx
function isLinkEnabled(item, modelType, exteriorColor, interiorColor, optionPicker) {
  switch (item.to) {
    case '/modelType':
      return modelType.isFetch;
    case '/exteriorColor':
      return exteriorColor.isFetch;
    case '/interiorColor':
      return interiorColor.isFetch;
    case '/optionPicker':
      return optionPicker.isFetch;
    default:
      return true;
  }
}
```
`isFetch`로 아직 패치 받지 않은 모델타입, 외장색상, 내장색상, 옵션 페이지는 Nav로 접근할 수 없도록 수정

## Issues
- close #235 