### PR TITLE
[Front-End] 다른 트림 선택 시에 fetch 초기화

### DIFF
--- a/frontend/src/pages/TrimSelectPage/Pick/index.jsx
+++ b/frontend/src/pages/TrimSelectPage/Pick/index.jsx
@@ -9,11 +9,28 @@ function Pick() {
   const pickTitleProps = { mainTitle: PICK.TITLE };
   const handleTrimCardClick = (trimData) => {
     if (trimData.id === trim.Id) return;
+
     setTrimState((prevState) => ({
       ...prevState,
       trim: {
         ...prevState.trim,
         Id: trimData.id,
+      },
+      modelType: {
+        ...prevState.modelType,
+        isFetch: false,
+      },
+      exteriorColor: {
+        ...prevState.exteriorColor,
+        isFetch: false,
+      },
+      interiorColor: {
+        ...prevState.interiorColor,
+        isFetch: false,
+      },
+      optionPicker: {
+        ...prevState.optionPicker,
+        isFetch: false,
       },
     }));
   };

--- a/frontend/src/pages/TrimSelectPage/index.jsx
+++ b/frontend/src/pages/TrimSelectPage/index.jsx
@@ -26,13 +26,6 @@ function TrimSelect() {
       setTrimState((prevState) => ({ ...prevState, page: 1 }));
     }
     fetchData();
-    setTrimState((prevState) => ({
-      ...prevState,
-      modelType: {
-        ...prevState.modelType,
-        isFetch: false,
-      },
-    }));
   }, []);
 
   const SectionProps = {


### PR DESCRIPTION
## 트림 선택 변경

이전에 선택했던 트림을 다시 선택할 경우에는 그대로 데이터 유지
다른 트림을 선택할 경우에는 fetch 초기화
```jsx
  const handleTrimCardClick = (trimData) => {
    if (trimData.id === trim.Id) return;

    setTrimState((prevState) => ({
      ...prevState,
      trim: {
        ...prevState.trim,
        Id: trimData.id,
      },
      modelType: {
        ...prevState.modelType,
        isFetch: false,
      },
      exteriorColor: {
        ...prevState.exteriorColor,
        isFetch: false,
      },
      interiorColor: {
        ...prevState.interiorColor,
        isFetch: false,
      },
      optionPicker: {
        ...prevState.optionPicker,
        isFetch: false,
      },
    }));
  };
```

## Issues
- close #238 