### PR TITLE
[Backend] 옵션 정보 목록 조회 API 구현 #116

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/global/ServerPath.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/global/ServerPath.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ServerPaths {
+public class ServerPath {
     @Value("${env.imageServerPath}")
     public String IMAGE_SERVER_PATH = "example-url";
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/global/dto/HMGDataDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/global/dto/HMGDataDto.java
@@ -1,6 +1,9 @@
 package softeer.wantcar.cartalog.global.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor

--- a/backend/src/main/java/softeer/wantcar/cartalog/global/dto/PowerTrainHMGDataDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/global/dto/PowerTrainHMGDataDto.java
@@ -1,6 +1,8 @@
 package softeer.wantcar.cartalog.global.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelQueryRepository.java
@@ -20,9 +20,8 @@ public class ModelQueryRepository {
     public BasicModel findBasicModelByName(String name) {
         SqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("name", name);
-        return jdbcTemplate.queryForObject(QueryString.findBasicModelByName,
-                parameters,
-                (rs, rowNum) -> getBasicModel(rs));
+        return jdbcTemplate.queryForObject("SELECT id, name, category FROM basic_models WHERE name=:name ",
+                parameters, (rs, rowNum) -> getBasicModel(rs));
     }
 
     private static BasicModel getBasicModel(ResultSet rs) throws SQLException {

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelQueryRepository.java
@@ -6,7 +6,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import softeer.wantcar.cartalog.entity.model.BasicModel;
-import softeer.wantcar.cartalog.trim.repository.QueryString;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
@@ -14,9 +14,11 @@ import softeer.wantcar.cartalog.trim.dto.OptionDetailResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimOptionDetailResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimPackageDetailResponseDto;
+import softeer.wantcar.cartalog.trim.service.TrimOptionService;
 
 import javax.websocket.server.PathParam;
 import java.util.List;
+import java.util.Objects;
 
 
 @Slf4j
@@ -26,28 +28,16 @@ import java.util.List;
 public class TrimOptionController {
     @Value("${env.imageServerPath}")
     private String imageServerPath = "example-url";
+    private final TrimOptionService trimOptionService;
 
     @GetMapping("")
-    public ResponseEntity<TrimOptionListResponseDto> getOptionInfos(@PathParam("trimId") Long trimId) {
-        if (trimId < 0) {
+    public ResponseEntity<TrimOptionListResponseDto> getOptionInfos(@PathParam("detailTrimId") Long detailTrimId,
+                                                                    @PathParam("interiorColorId") Long interiorColorId) {
+        TrimOptionListResponseDto trimOptionList = trimOptionService.getTrimOptionList(detailTrimId, interiorColorId);
+        if (Objects.isNull(trimOptionList)) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        TrimOptionListResponseDto trimOptionListResponseDto = TrimOptionListResponseDto.builder()
-                .multipleSelectParentCategory(List.of("상세 품목", "악세사리"))
-                .selectOptions(List.of(getTrimOptionDto("O11",
-                        "2열 통풍시트",
-                        "상세품목",
-                        "시트",
-                        "2_cool_seat.jpg",
-                        350000)))
-                .defaultOptions(List.of(getTrimOptionDto("O5",
-                        "디젤 2.2 엔진",
-                        null,
-                        "파워트레인/성능",
-                        "/palisade/le-blanc/options/dieselengine2.2_s.jpg",
-                        0)))
-                .build();
-        return new ResponseEntity<>(trimOptionListResponseDto, HttpStatus.OK);
+        return new ResponseEntity<>(trimOptionList, HttpStatus.OK);
     }
 
     //TODO: NumberFormatException 처리 필요

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
@@ -29,8 +29,8 @@ public class TrimOptionController {
 
     @GetMapping("")
     public ResponseEntity<TrimOptionListResponseDto> getOptionInfos(@PathParam("detailTrimId") Long detailTrimId,
-                                                                    @PathParam("interiorColorId") Long interiorColorId) {
-        TrimOptionListResponseDto trimOptionList = trimOptionService.getTrimOptionList(detailTrimId, interiorColorId);
+                                                                    @PathParam("interiorColorCode") String interiorColorCode) {
+        TrimOptionListResponseDto trimOptionList = trimOptionService.getTrimOptionList(detailTrimId, interiorColorCode);
         if (Objects.isNull(trimOptionList)) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
@@ -1,5 +1,6 @@
 package softeer.wantcar.cartalog.trim.controller;
 
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,12 +22,26 @@ import java.util.Objects;
 
 
 @Slf4j
+@Api(tags = {"트림 옵션 관련 API"})
 @RestController
 @RequestMapping("/models/trims/options")
 @RequiredArgsConstructor
 public class TrimOptionController {
     private final TrimOptionService trimOptionService;
 
+    @ApiOperation(
+            value = "트림 옵션 목록 조회",
+            notes = "트림의 옵션 목록과 복수 선택 가능 카테고리 목록을 조회한다")
+    @ApiImplicitParams({
+            @ApiImplicitParam(
+                    name = "detailTrimId", value = "세부 트림 식별자", required = true,
+                    dataType = "java.lang.Long", paramType = "query", example = "9"),
+            @ApiImplicitParam(
+                    name = "interiorColorCode", value = "내부 색상 코드", required = true,
+                    dataType = "java.lang.String", paramType = "query", example = "I50")})
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "존재하지 않는 세부 트림 식별자입니다."),
+            @ApiResponse(code = 500, message = "서버에서 처리하지 못했습니다. 관리자에게 문의하세요.")})
     @GetMapping("")
     public ResponseEntity<TrimOptionListResponseDto> getOptionInfos(@PathParam("detailTrimId") Long detailTrimId,
                                                                     @PathParam("interiorColorCode") String interiorColorCode) {

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
@@ -34,13 +34,13 @@ public class TrimOptionController {
         }
         TrimOptionListResponseDto trimOptionListResponseDto = TrimOptionListResponseDto.builder()
                 .multipleSelectParentCategory(List.of("상세 품목", "악세사리"))
-                .selectOptions(List.of(getTrimOptionDto(11L,
+                .selectOptions(List.of(getTrimOptionDto("O11",
                         "2열 통풍시트",
                         "상세품목",
                         "시트",
                         "2_cool_seat.jpg",
                         350000)))
-                .defaultOptions(List.of(getTrimOptionDto(5L,
+                .defaultOptions(List.of(getTrimOptionDto("O5",
                         "디젤 2.2 엔진",
                         null,
                         "파워트레인/성능",
@@ -88,7 +88,7 @@ public class TrimOptionController {
     }
 
     private TrimOptionListResponseDto.TrimOptionDto getTrimOptionDto(
-            Long id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
+            String id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
         return TrimOptionListResponseDto.TrimOptionDto.builder()
                 .id(id)
                 .name(name)

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/controller/TrimOptionController.java
@@ -2,7 +2,6 @@ package softeer.wantcar.cartalog.trim.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,8 +25,6 @@ import java.util.Objects;
 @RequestMapping("/models/trims/options")
 @RequiredArgsConstructor
 public class TrimOptionController {
-    @Value("${env.imageServerPath}")
-    private String imageServerPath = "example-url";
     private final TrimOptionService trimOptionService;
 
     @GetMapping("")
@@ -75,19 +72,5 @@ public class TrimOptionController {
                 .hmgData(List.of(new HMGDataDto("주행 중 실제로", "73.2", "15,000km 당")))
                 .build();
         return new ResponseEntity<>(trimOptionDetail, HttpStatus.OK);
-    }
-
-    private TrimOptionListResponseDto.TrimOptionDto getTrimOptionDto(
-            String id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
-        return TrimOptionListResponseDto.TrimOptionDto.builder()
-                .id(id)
-                .name(name)
-                .parentCategory(parentCategory)
-                .childCategory(childCategory)
-                .imageUrl(imageServerPath + imageUrl)
-                .price(price)
-                .chosen(38)
-                .hashTags(List.of("장거리 운전"))
-                .build();
     }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/dto/TrimInteriorColorListResponseDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/dto/TrimInteriorColorListResponseDto.java
@@ -3,12 +3,10 @@ package softeer.wantcar.cartalog.trim.dto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
-import softeer.wantcar.cartalog.entity.model.ModelInteriorColor;
 import softeer.wantcar.cartalog.global.annotation.TestMethod;
 import softeer.wantcar.cartalog.global.utils.CompareUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/dto/TrimOptionListResponseDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/dto/TrimOptionListResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import softeer.wantcar.cartalog.trim.repository.TrimOptionQueryRepository;
 
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class TrimOptionListResponseDto {
     @AllArgsConstructor
     @EqualsAndHashCode
     public static class TrimOptionDto {
-        private Long id;
+        private String id;
         private String name;
         private String parentCategory;
         private String childCategory;
@@ -30,5 +31,17 @@ public class TrimOptionListResponseDto {
         private int chosen;
         private List<String> hashTags;
         private boolean hasHMGData;
+
+        public TrimOptionDto(TrimOptionQueryRepository.TrimOptionInfo trimOptionInfo, int chosen) {
+            this.id = trimOptionInfo.getId();
+            this.name = trimOptionInfo.getName();
+            this.parentCategory = trimOptionInfo.getParentCategory();
+            this.childCategory = trimOptionInfo.getChildCategory();
+            this.imageUrl = trimOptionInfo.getImageUrl();
+            this.price = trimOptionInfo.getPrice();
+            this.chosen = chosen;
+            this.hashTags = trimOptionInfo.getHashTags();
+            this.hasHMGData = trimOptionInfo.isHasHMGData();
+        }
     }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -5,8 +5,7 @@ public class QueryString {
     }
 
     protected static final String findBasicModelByName =
-            "SELECT id, name, category FROM basic_models WHERE name=:name " +
-            ";";
+            "SELECT id, name, category FROM basic_models WHERE name=:name ";
 
     protected static final String findTrimsByBasicModelId =
             "SELECT  " +
@@ -82,8 +81,7 @@ public class QueryString {
             "    ) " +
             "  ) AS mt" +
             ") AS mt  " +
-            "ON t.basic_model_id= :basicModelId " +
-            ";";
+            "ON t.basic_model_id= :basicModelId ";
 
     protected static final String findDetailTrimInfoByTrimIdAndModelTypes =
             "SELECT " +
@@ -102,8 +100,7 @@ public class QueryString {
             "    GROUP BY dm.id " +
             "    HAVING COUNT(DISTINCT dmdo.model_option_id) = :modelTypeCount " +
             ") AS dm ON dt.detail_model_id=dm.id " +
-            "WHERE dt.trim_id = :trimId " +
-            ";";
+            "WHERE dt.trim_id = :trimId ";
 
     protected static String findOptionsByDetailTrimId =
             "SELECT DISTINCT " +
@@ -125,8 +122,7 @@ public class QueryString {
             "LEFT OUTER JOIN detail_trim_option_interior_color_condition AS dtoicc ON dtoicc.detail_trim_option_id=dto.id " +
             "LEFT OUTER JOIN model_option_hash_tags AS moht ON moht.model_option_id = dto.model_option_id " +
             "LEFT OUTER JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
-            "WHERE visibility=true AND detail_trim_id= :detailTrimId  " +
-            "; ";
+            "WHERE visibility=true AND detail_trim_id= :detailTrimId  ";
 
     public static String findPackagesByTrimId =
             "SELECT DISTINCT " +
@@ -148,8 +144,7 @@ public class QueryString {
             "JOIN trim_package_options AS tpo ON tpo.trim_package_id=dtp.id " +
             "JOIN detail_trim_options AS dto ON dto.id=tpo.detail_trim_option_id " +
             "JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
-            "WHERE dtp.detail_trim_id= :detailTrimId " +
-            ";";
+            "WHERE dtp.detail_trim_id= :detailTrimId ";
 
     protected static final String findTrimExteriorColorByTrimId =
             "SELECT " +
@@ -188,5 +183,11 @@ public class QueryString {
             "  INNER JOIN model_exterior_colors " +
             "  ON trim_exterior_colors.model_exterior_color_id = model_exterior_colors.id " +
             "  WHERE trim_exterior_colors.trim_id = :trimId " +
-            "    AND model_exterior_colors.color_code = :colorCode)";
+            "    AND model_exterior_colors.color_code = :colorCode);";
+
+    protected static final String findMultipleSelectableCategories =
+            "SELECT " +
+            "   category " +
+            "FROM model_option_parent_categories " +
+            "WHERE multiple_select=true";
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -128,7 +128,7 @@ public class QueryString {
             "WHERE visibility=true AND detail_trim_id= :detailTrimId  " +
             "; ";
 
-    public static String findPackagesByTrimIdAndInteriorColorId =
+    public static String findPackagesByTrimId =
             "SELECT DISTINCT " +
             "   dtp.id AS id, " +
             "   dtp.name AS name, " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -5,7 +5,8 @@ public class QueryString {
     }
 
     public static final String findBasicModelByName =
-            "SELECT id, name, category FROM basic_models WHERE name=:name";
+            "SELECT id, name, category FROM basic_models WHERE name=:name " +
+            ";";
 
     public static final String findTrimsByBasicModelId =
             "SELECT  " +
@@ -81,14 +82,17 @@ public class QueryString {
             "    ) " +
             "  ) AS mt" +
             ") AS mt  " +
-            "ON t.basic_model_id= :basicModelId;";
+            "ON t.basic_model_id= :basicModelId " +
+            ";";
 
     public static final String findDetailTrimInfoByTrimIdAndModelTypes =
             "SELECT " +
             "  dt.id AS detailTrimId, " +
             "  dm.displacement AS displacement, " +
             "  dm.fuel_efficiency AS fuelEfficiency " +
+
             "FROM detail_trims AS dt " +
+
             "JOIN " +
             "  ( " +
             "    SELECT dm.id, dm.displacement, dm.fuel_efficiency " +
@@ -98,7 +102,53 @@ public class QueryString {
             "    GROUP BY dm.id " +
             "    HAVING COUNT(DISTINCT dmdo.model_option_id) = :modelTypeCount " +
             ") AS dm ON dt.detail_model_id=dm.id " +
-            "WHERE dt.trim_id = :trimId;";
+            "WHERE dt.trim_id = :trimId " +
+            ";";
+
+    public static String findOptionsByTrimIdAndInteriorColorId =
+            "SELECT DISTINCT " +
+            "   dto.id AS id, " +
+            "   dto.price AS price, " +
+            "   dto.color_condition AS colorCondition, " +
+            "   dto.basic AS basic, " +
+            "   mo.name AS name, " +
+            "   mo.parent_category AS parentCategory, " +
+            "   mo.child_category AS childCategory, " +
+            "   mo.image_url AS imageUrl, " +
+            "   dtoicc.trim_interior_color_id AS trimInteriorColorId, " +
+            "   moht.hash_tag AS hashTag, " +
+            "   hmg.model_option_id AS modelOptionId" +
+
+            "FROM detail_trim_options AS dto " +
+
+            "JOIN model_options AS mo ON mo.id=dto.model_option_id " +
+            "LEFT OUTER JOIN detail_trim_option_interior_color_condition AS dtoicc ON dtoicc.detail_trim_option_id=dto.id " +
+            "LEFT OUTER JOIN model_option_hash_tags AS moht ON moht.model_option_id = dto.model_option_id " +
+            "LEFT OUTER JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
+            "WHERE visibility=true AND detail_trim_id= :detailTrimId  " +
+            "; ";
+
+    public static String findPackagesByTrimIdAndInteriorColorId =
+            "SELECT DISTINCT " +
+            "   dtp.id AS id, " +
+            "   dtp.name AS name, " +
+            "   dtp.price AS price, " +
+            "   dtp.parent_category AS parentCategory, " +
+            "   dtp.color_condition AS colorCondition, " +
+            "   dtp.image_url AS imageUrl, " +
+            "   dtpicc.trim_interior_color_id AS trimInteriorColorId, " +
+            "   pht.hash_tag AS hashTag, " +
+            "   hmg.model_option_id AS modelOptionId" +
+
+            "FROM detail_trim_packages AS dtp " +
+
+            "LEFT OUTER JOIN detail_trim_package_interior_color_condition AS dtpicc ON dtpicc.detail_trim_package_id=dtp.id " +
+            "LEFT OUTER JOIN package_hash_tags AS pht ON pht.package_id=dtp.id " +
+            "JOIN trim_package_options AS tpo ON tpo.trim_package_id=dtp.id " +
+            "JOIN detail_trim_options AS dto ON dto.id=tpo.detail_trim_option_id " +
+            "JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
+            "WHERE dtp.detail_trim_id=: detailTrimId " +
+            ";";
 
     protected static final String findTrimExteriorColorByTrimId =
             "SELECT " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -6,96 +6,96 @@ public class QueryString {
 
     protected static final String findTrimsByBasicModelId =
             "SELECT  " +
-            "(SELECT name FROM basic_models where id= :basicModelId) AS modelName,  " +
-            "t.id AS trimId,  " +
-            "t.name AS trimName,  " +
-            "t.description AS description,  " +
-            "t.min_price AS minPrice,  " +
-            "t.max_price AS maxPrice,  " +
-            "t.exterior_image_url AS exteriorImageUrl,  " +
-            "t.interior_image_url AS interiorImageUrl,  " +
-            "t.wheel_image_url AS wheelImageUrl,  " +
-            "tb.name AS hmgName,  " +
-            "tb.val AS hmgVal,  " +
-            "tb.measure AS hmgMeasure,  " +
-            "tb.unit AS hmgUnit,  " +
-            "mt.child_category AS defaultModelTypeChildCategory,  " +
-            "mt.id AS defaultModelTypeOptionId,  " +
-            "mt.name AS defaultModelTypeOptionName,  " +
-            "mt.price AS defaultModelTypeOptionPrice,  " +
-            "eic.model_exterior_color_code AS defaultExteriorColorCode,  " +
-            "eic.model_interior_color_code AS defaultInteriorColorCode  " +
+            "   (SELECT name FROM basic_models where id= :basicModelId) AS modelName,  " +
+            "   t.id AS trimId,  " +
+            "   t.name AS trimName,  " +
+            "   t.description AS description,  " +
+            "   t.min_price AS minPrice,  " +
+            "   t.max_price AS maxPrice,  " +
+            "   t.exterior_image_url AS exteriorImageUrl,  " +
+            "   t.interior_image_url AS interiorImageUrl,  " +
+            "   t.wheel_image_url AS wheelImageUrl,  " +
+            "   tb.name AS hmgName,  " +
+            "   tb.val AS hmgVal,  " +
+            "   tb.measure AS hmgMeasure,  " +
+            "   tb.unit AS hmgUnit,  " +
+            "   mt.child_category AS defaultModelTypeChildCategory,  " +
+            "   mt.id AS defaultModelTypeOptionId,  " +
+            "   mt.name AS defaultModelTypeOptionName,  " +
+            "   mt.price AS defaultModelTypeOptionPrice,  " +
+            "   eic.model_exterior_color_code AS defaultExteriorColorCode,  " +
+            "   eic.model_interior_color_code AS defaultInteriorColorCode  " +
 
             "FROM trims AS t  " +
 
             "LEFT OUTER JOIN  " +
             "(  " +
-            "  SELECT sub_tb.trim_id, (SELECT name FROM model_options WHERE id=sub_tb.model_option_id) AS name, sub_tb.val, sub_tb.measure, sub_tb.unit  " +
-            "  FROM (  " +
-            "    SELECT DISTINCT trim_id, dto.model_option_id, val, measure, unit  " +
-            "    FROM hmg_data AS hmg  " +
-            "    JOIN detail_trim_options AS dto ON hmg.model_option_id = dto.model_option_id  " +
-            "    JOIN detail_trims AS dt ON dto.detail_trim_id = dt.id  " +
-            "    WHERE measure='15,000km 당' AND trim_id IN ( select id from trims where basic_model_id= :basicModelId)  " +
-            "  ) AS sub_tb  " +
-            "  ORDER BY sub_tb.trim_id, sub_tb.val desc  " +
+            "   SELECT sub_tb.trim_id, (SELECT name FROM model_options WHERE id=sub_tb.model_option_id) AS name, sub_tb.val, sub_tb.measure, sub_tb.unit  " +
+            "   FROM (  " +
+            "       SELECT DISTINCT trim_id, dto.model_option_id, val, measure, unit  " +
+            "       FROM hmg_data AS hmg  " +
+            "       JOIN detail_trim_options AS dto ON hmg.model_option_id = dto.model_option_id  " +
+            "       JOIN detail_trims AS dt ON dto.detail_trim_id = dt.id  " +
+            "       WHERE measure='15,000km 당' AND trim_id IN ( select id from trims where basic_model_id= :basicModelId)  " +
+            "   ) AS sub_tb  " +
+            "   ORDER BY sub_tb.trim_id, sub_tb.val desc  " +
             ") AS tb  " +
             "ON t.id=tb.trim_id  " +
 
             "JOIN  " +
             "(  " +
-            "  SELECT  " +
-            "  trim_id,  " +
-            "  color_code as model_exterior_color_code,  " +
-            "  model_interior_color_code,  " +
-            "  price  " +
-            "  FROM  " +
-            "  (  " +
-            "    SELECT trim_id, mec.color_code, model_exterior_color_id, model_interior_color_code, mec.price,  " +
-            "    ROW_NUMBER() OVER (PARTITION BY trim_id) AS row_num  " +
-            "    FROM trim_exterior_colors AS ec  " +
-            "    JOIN trim_interior_colors AS ic ON ec.id=ic.trim_exterior_color_id  " +
-            "    JOIN model_exterior_colors AS mec ON mec.id=model_exterior_color_id  " +
-            "    WHERE mec.price=0  " +
-            "  ) AS eic  " +
-            "  WHERE row_num=1  " +
+            "   SELECT  " +
+            "   trim_id,  " +
+            "   color_code as model_exterior_color_code,  " +
+            "   model_interior_color_code,  " +
+            "   price  " +
+            "   FROM  " +
+            "   (  " +
+            "       SELECT trim_id, mec.color_code, model_exterior_color_id, model_interior_color_code, mec.price,  " +
+            "       ROW_NUMBER() OVER (PARTITION BY trim_id) AS row_num  " +
+            "       FROM trim_exterior_colors AS ec  " +
+            "       JOIN trim_interior_colors AS ic ON ec.id=ic.trim_exterior_color_id  " +
+            "       JOIN model_exterior_colors AS mec ON mec.id=model_exterior_color_id  " +
+            "       WHERE mec.price=0  " +
+            "   ) AS eic  " +
+            "   WHERE row_num=1  " +
             ") AS eic  " +
             "ON t.id=eic.trim_id  " +
 
             "JOIN  " +
             "(  " +
-            "  SELECT child_category, id, name, price_if_model_type_option AS price  " +
-            "  FROM  " +
-            "  (  " +
-            "    SELECT *, ROW_NUMBER() OVER (PARTITION BY child_category ORDER BY id) AS row_num  " +
-            "    FROM model_options  " +
-            "    WHERE id IN  " +
-            "    (  " +
-            "      SELECT distinct model_option_id  " +
-            "      FROM detail_model_decision_options  " +
-            "      WHERE detail_model_id IN  " +
-            "        (SELECT id FROM detail_models WHERE basic_model_id= :basicModelId)  " +
-            "    ) " +
-            "  ) AS mt" +
+            "   SELECT child_category, id, name, price_if_model_type_option AS price  " +
+            "   FROM  " +
+            "   (  " +
+            "       SELECT *, ROW_NUMBER() OVER (PARTITION BY child_category ORDER BY id) AS row_num  " +
+            "       FROM model_options  " +
+            "       WHERE id IN  " +
+            "       (  " +
+            "           SELECT distinct model_option_id  " +
+            "           FROM detail_model_decision_options  " +
+            "           WHERE detail_model_id IN  " +
+            "               (SELECT id FROM detail_models WHERE basic_model_id= :basicModelId)  " +
+            "       ) " +
+            "   ) AS mt" +
             ") AS mt  " +
             "ON t.basic_model_id= :basicModelId ";
 
     protected static final String findDetailTrimInfoByTrimIdAndModelTypes =
             "SELECT " +
-            "  dt.id AS detailTrimId, " +
-            "  dm.displacement AS displacement, " +
-            "  dm.fuel_efficiency AS fuelEfficiency " +
+            "   dt.id AS detailTrimId, " +
+            "   dm.displacement AS displacement, " +
+            "   dm.fuel_efficiency AS fuelEfficiency " +
 
             "FROM detail_trims AS dt " +
 
             "JOIN " +
-            "  ( " +
-            "    SELECT dm.id, dm.displacement, dm.fuel_efficiency " +
-            "    FROM detail_models AS dm " +
-            "    JOIN detail_model_decision_options AS dmdo ON dm.id = dmdo.detail_model_id " +
-            "    WHERE dmdo.model_option_id IN (:modelTypeIds) " +
-            "    GROUP BY dm.id " +
-            "    HAVING COUNT(DISTINCT dmdo.model_option_id) = :modelTypeCount " +
+            "( " +
+            "   SELECT dm.id, dm.displacement, dm.fuel_efficiency " +
+            "   FROM detail_models AS dm " +
+            "   JOIN detail_model_decision_options AS dmdo ON dm.id = dmdo.detail_model_id " +
+            "   WHERE dmdo.model_option_id IN (:modelTypeIds) " +
+            "   GROUP BY dm.id " +
+            "   HAVING COUNT(DISTINCT dmdo.model_option_id) = :modelTypeCount " +
             ") AS dm ON dt.detail_model_id=dm.id " +
             "WHERE dt.trim_id = :trimId ";
 
@@ -145,16 +145,16 @@ public class QueryString {
 
     protected static final String findTrimExteriorColorByTrimId =
             "SELECT " +
-            "  code, " +
-            "  name, " +
-            "  image_url, " +
-            "  price, " +
-            "  exterior_image_directory " +
+            "   code, " +
+            "   name, " +
+            "   image_url, " +
+            "   price, " +
+            "   exterior_image_directory " +
             "FROM trim_exterior_colors " +
             "INNER JOIN model_exterior_colors " +
             "ON trim_exterior_colors.model_exterior_color_id = model_exterior_colors.id " +
             "INNER JOIN colors " +
-            "  ON model_exterior_colors.color_code = colors.code " +
+            "   ON model_exterior_colors.color_code = colors.code " +
             "WHERE trim_id = :trimId";
 
     protected static final String findTrimIdByModelNameAndTrimName =
@@ -166,21 +166,23 @@ public class QueryString {
 
     protected static final String findTrimInteriorColorByTrimIdAndExteriorColorCode =
             "SELECT " +
-            "  model_interior_colors.code, " +
-            "  model_interior_colors.name, " +
-            "  model_interior_colors.price, " +
-            "  model_interior_colors.image_url, " +
-            "  model_interior_colors.interior_image_url " +
+            "   model_interior_colors.code, " +
+            "   model_interior_colors.name, " +
+            "   model_interior_colors.price, " +
+            "   model_interior_colors.image_url, " +
+            "   model_interior_colors.interior_image_url " +
             "FROM model_interior_colors " +
             "INNER JOIN trim_interior_colors " +
             "ON model_interior_colors.code = trim_interior_colors.model_interior_color_code " +
             "WHERE trim_exterior_color_id = " +
-            "  (SELECT trim_exterior_colors.id " +
-            "  FROM trim_exterior_colors " +
-            "  INNER JOIN model_exterior_colors " +
-            "  ON trim_exterior_colors.model_exterior_color_id = model_exterior_colors.id " +
-            "  WHERE trim_exterior_colors.trim_id = :trimId " +
-            "    AND model_exterior_colors.color_code = :colorCode);";
+            "   (" +
+            "       SELECT trim_exterior_colors.id " +
+            "       FROM trim_exterior_colors " +
+            "       INNER JOIN model_exterior_colors " +
+            "       ON trim_exterior_colors.model_exterior_color_id = model_exterior_colors.id " +
+            "       WHERE trim_exterior_colors.trim_id = :trimId " +
+            "           AND model_exterior_colors.color_code = :colorCode" +
+            "   );";
 
     protected static final String findMultipleSelectableCategories =
             "SELECT " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -132,13 +132,14 @@ public class QueryString {
             "SELECT DISTINCT " +
             "   dtp.id AS id, " +
             "   dtp.name AS name, " +
-            "   dtp.price AS price, " +
             "   dtp.parent_category AS parentCategory, " +
             "   dtp.color_condition AS colorCondition, " +
             "   dtp.image_url AS imageUrl, " +
+            "   dtp.price AS price, " +
+            "   dto.color_condition AS colorCondition, " +
             "   dtpicc.trim_interior_color_id AS trimInteriorColorId, " +
             "   pht.hash_tag AS hashTag, " +
-            "   hmg.model_option_id AS modelOptionId" +
+            "   hmg.model_option_id AS hmgModelOptionId " +
 
             "FROM detail_trim_packages AS dtp " +
 
@@ -147,7 +148,7 @@ public class QueryString {
             "JOIN trim_package_options AS tpo ON tpo.trim_package_id=dtp.id " +
             "JOIN detail_trim_options AS dto ON dto.id=tpo.detail_trim_option_id " +
             "JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
-            "WHERE dtp.detail_trim_id=: detailTrimId " +
+            "WHERE dtp.detail_trim_id= :detailTrimId " +
             ";";
 
     protected static final String findTrimExteriorColorByTrimId =

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -4,9 +4,6 @@ public class QueryString {
     private QueryString() {
     }
 
-    protected static final String findBasicModelByName =
-            "SELECT id, name, category FROM basic_models WHERE name=:name ";
-
     protected static final String findTrimsByBasicModelId =
             "SELECT  " +
             "(SELECT name FROM basic_models where id= :basicModelId) AS modelName,  " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -4,11 +4,11 @@ public class QueryString {
     private QueryString() {
     }
 
-    public static final String findBasicModelByName =
+    protected static final String findBasicModelByName =
             "SELECT id, name, category FROM basic_models WHERE name=:name " +
             ";";
 
-    public static final String findTrimsByBasicModelId =
+    protected static final String findTrimsByBasicModelId =
             "SELECT  " +
             "(SELECT name FROM basic_models where id= :basicModelId) AS modelName,  " +
             "t.id AS trimId,  " +
@@ -85,7 +85,7 @@ public class QueryString {
             "ON t.basic_model_id= :basicModelId " +
             ";";
 
-    public static final String findDetailTrimInfoByTrimIdAndModelTypes =
+    protected static final String findDetailTrimInfoByTrimIdAndModelTypes =
             "SELECT " +
             "  dt.id AS detailTrimId, " +
             "  dm.displacement AS displacement, " +
@@ -105,7 +105,7 @@ public class QueryString {
             "WHERE dt.trim_id = :trimId " +
             ";";
 
-    public static String findOptionsByDetailTrimId =
+    protected static String findOptionsByDetailTrimId =
             "SELECT DISTINCT " +
             "   dto.id AS id, " +
             "   mo.name AS name, " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -109,7 +109,7 @@ public class QueryString {
             "   dto.price AS price, " +
             "   dto.basic AS basic, " +
             "   dto.color_condition AS colorCondition, " +
-            "   dtoicc.trim_interior_color_id AS trimInteriorColorId, " +
+            "   tic.model_interior_color_code AS trimInteriorColorCode, " +
             "   moht.hash_tag AS hashTag, " +
             "   hmg.model_option_id AS hmgModelOptionId " +
 
@@ -117,11 +117,12 @@ public class QueryString {
 
             "JOIN model_options AS mo ON mo.id=dto.model_option_id " +
             "LEFT OUTER JOIN detail_trim_option_interior_color_condition AS dtoicc ON dtoicc.detail_trim_option_id=dto.id " +
+            "LEFT OUTER JOIN trim_interior_colors AS tic ON tic.id = dtoicc.trim_interior_color_id " +
             "LEFT OUTER JOIN model_option_hash_tags AS moht ON moht.model_option_id = dto.model_option_id " +
             "LEFT OUTER JOIN hmg_data AS hmg ON hmg.model_option_id=dto.model_option_id " +
             "WHERE visibility=true AND detail_trim_id= :detailTrimId  ";
 
-    public static String findPackagesByTrimId =
+    public static final String findPackagesByTrimId =
             "SELECT DISTINCT " +
             "   dtp.id AS id, " +
             "   dtp.name AS name, " +
@@ -130,13 +131,14 @@ public class QueryString {
             "   dtp.image_url AS imageUrl, " +
             "   dtp.price AS price, " +
             "   dto.color_condition AS colorCondition, " +
-            "   dtpicc.trim_interior_color_id AS trimInteriorColorId, " +
+            "   tic.model_interior_color_code AS trimInteriorColorCode, " +
             "   pht.hash_tag AS hashTag, " +
             "   hmg.model_option_id AS hmgModelOptionId " +
 
             "FROM detail_trim_packages AS dtp " +
 
             "LEFT OUTER JOIN detail_trim_package_interior_color_condition AS dtpicc ON dtpicc.detail_trim_package_id=dtp.id " +
+            "LEFT OUTER JOIN trim_interior_colors AS tic ON tic.id = dtpicc.trim_interior_color_id " +
             "LEFT OUTER JOIN package_hash_tags AS pht ON pht.package_id=dtp.id " +
             "JOIN trim_package_options AS tpo ON tpo.trim_package_id=dtp.id " +
             "JOIN detail_trim_options AS dto ON dto.id=tpo.detail_trim_option_id " +

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/QueryString.java
@@ -105,19 +105,19 @@ public class QueryString {
             "WHERE dt.trim_id = :trimId " +
             ";";
 
-    public static String findOptionsByTrimIdAndInteriorColorId =
+    public static String findOptionsByDetailTrimId =
             "SELECT DISTINCT " +
             "   dto.id AS id, " +
-            "   dto.price AS price, " +
-            "   dto.color_condition AS colorCondition, " +
-            "   dto.basic AS basic, " +
             "   mo.name AS name, " +
             "   mo.parent_category AS parentCategory, " +
             "   mo.child_category AS childCategory, " +
             "   mo.image_url AS imageUrl, " +
+            "   dto.price AS price, " +
+            "   dto.basic AS basic, " +
+            "   dto.color_condition AS colorCondition, " +
             "   dtoicc.trim_interior_color_id AS trimInteriorColorId, " +
             "   moht.hash_tag AS hashTag, " +
-            "   hmg.model_option_id AS modelOptionId" +
+            "   hmg.model_option_id AS hmgModelOptionId " +
 
             "FROM detail_trim_options AS dto " +
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImpl.java
@@ -7,7 +7,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.wantcar.cartalog.global.ServerPaths;
+import softeer.wantcar.cartalog.global.ServerPath;
 import softeer.wantcar.cartalog.trim.dto.TrimExteriorColorListResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimInteriorColorListResponseDto;
 
@@ -18,7 +18,7 @@ import java.util.List;
 @Repository
 @RequiredArgsConstructor
 public class TrimColorQueryRepositoryImpl implements TrimColorQueryRepository {
-    private final ServerPaths serverPaths;
+    private final ServerPath serverPath;
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     @Builder
@@ -63,9 +63,9 @@ public class TrimColorQueryRepositoryImpl implements TrimColorQueryRepository {
         return TrimExteriorColorQueryResult.builder()
                 .code(rs.getString("code"))
                 .name(rs.getString("name"))
-                .imageUrl(serverPaths.attachImageServerPath(rs.getString("image_url")))
+                .imageUrl(serverPath.attachImageServerPath(rs.getString("image_url")))
                 .price(rs.getInt("price"))
-                .exteriorImageDirectory(serverPaths.attachImageServerPath(rs.getString("exterior_image_directory")))
+                .exteriorImageDirectory(serverPath.attachImageServerPath(rs.getString("exterior_image_directory")))
                 .build();
     }
 
@@ -73,9 +73,9 @@ public class TrimColorQueryRepositoryImpl implements TrimColorQueryRepository {
         return TrimInteriorColorQueryResult.builder()
                 .code(rs.getString("code"))
                 .name(rs.getString("name"))
-                .imageUrl(serverPaths.attachImageServerPath(rs.getString("image_url")))
+                .imageUrl(serverPath.attachImageServerPath(rs.getString("image_url")))
                 .price(rs.getInt("price"))
-                .interiorImageUrl(serverPaths.attachImageServerPath(rs.getString("interior_image_url")))
+                .interiorImageUrl(serverPath.attachImageServerPath(rs.getString("interior_image_url")))
                 .build();
     }
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -1,34 +1,29 @@
-package softeer.wantcar.cartalog.trim.dto;
+package softeer.wantcar.cartalog.trim.repository;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 
 import java.util.List;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@EqualsAndHashCode
-public class TrimOptionListResponseDto {
-    private List<String> multipleSelectParentCategory;
-    private List<TrimOptionDto> selectOptions;
-    private List<TrimOptionDto> defaultOptions;
-
+public interface TrimOptionQueryRepository {
     @Getter
     @Builder
     @AllArgsConstructor
-    @EqualsAndHashCode
-    public static class TrimOptionDto {
+    public static class TrimOptionInfo {
         private Long id;
         private String name;
         private String parentCategory;
         private String childCategory;
         private String imageUrl;
         private int price;
-        private int chosen;
+        private boolean basic;
+        private boolean colorCondition;
+        private List<Long> trimInteriorColorIds;
         private List<String> hashTags;
         private boolean hasHMGData;
     }
+
+    List<TrimOptionInfo> findOptionsByDetailTrimId(Long detailTrimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -26,6 +26,6 @@ public interface TrimOptionQueryRepository {
         private boolean hasHMGData;
     }
 
-    List<String> findMultipleSelectCategories();
+    List<String> findMultipleSelectableCategories();
     List<TrimOptionInfo> findOptionsByDetailTrimId(Long detailTrimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -21,7 +21,7 @@ public interface TrimOptionQueryRepository {
         private int price;
         private boolean basic;
         private boolean colorCondition;
-        private List<Long> trimInteriorColorIds;
+        private List<String> trimInteriorColorIds;
         private List<String> hashTags;
         private boolean hasHMGData;
     }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import java.util.List;
 
 public interface TrimOptionQueryRepository {
+    List<TrimOptionInfo> findPackagesByDetailTrimId(Long detailTrimId);
+
     @Getter
     @Builder
     @AllArgsConstructor

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -26,5 +26,6 @@ public interface TrimOptionQueryRepository {
         private boolean hasHMGData;
     }
 
+    List<String> findMultipleSelectCategories();
     List<TrimOptionInfo> findOptionsByDetailTrimId(Long detailTrimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -27,5 +27,6 @@ public interface TrimOptionQueryRepository {
     }
 
     List<String> findMultipleSelectableCategories();
+
     List<TrimOptionInfo> findOptionsByDetailTrimId(Long detailTrimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -13,7 +13,7 @@ public interface TrimOptionQueryRepository {
     @Builder
     @AllArgsConstructor
     class TrimOptionInfo {
-        private Long id;
+        private String id;
         private String name;
         private String parentCategory;
         private String childCategory;

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepository.java
@@ -3,7 +3,6 @@ package softeer.wantcar.cartalog.trim.repository;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 
 import java.util.List;
 
@@ -11,7 +10,7 @@ public interface TrimOptionQueryRepository {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class TrimOptionInfo {
+    class TrimOptionInfo {
         private Long id;
         private String name;
         private String parentCategory;

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -66,7 +66,7 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
     }
 
     private List<TrimOptionInfo> getTrimOptionInfos(List<TrimOptionQueryResult> queryResults) {
-        if(queryResults.isEmpty()) {
+        if (queryResults.isEmpty()) {
             return null;
         }
         Map<String, List<TrimOptionQueryResult>> trimOptionQueryResults = queryResults.stream()
@@ -130,7 +130,7 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
                 .hashTag(rs.getString("hashTag"))
                 .hmgModelOptionId(rs.getLong("hmgModelOptionId"));
 
-        if(isOption) {
+        if (isOption) {
             builder.basic(rs.getBoolean("basic"));
             builder.childCategory(rs.getString("childCategory"));
         }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -51,7 +51,7 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
     }
 
     @Override
-    public List<String> findMultipleSelectCategories() {
+    public List<String> findMultipleSelectableCategories() {
         return jdbcTemplate.query(QueryString.findMultipleSelectableCategories,
                 (rs, rowNum) -> rs.getString("category"));
     }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -13,7 +12,10 @@ import softeer.wantcar.cartalog.global.ServerPath;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Repository

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -12,10 +13,7 @@ import softeer.wantcar.cartalog.global.ServerPath;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Repository
@@ -48,6 +46,12 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
         List<TrimOptionQueryResult> queryResults = jdbcTemplate.query(QueryString.findPackagesByTrimId,
                 parameters, (rs, rowNum) -> getTrimOptionQueryResult(rs, false));
         return getTrimOptionInfos(detailTrimId, queryResults);
+    }
+
+    @Override
+    public List<String> findMultipleSelectCategories() {
+        return jdbcTemplate.query(QueryString.findMultipleSelectableCategories,
+                (rs, rowNum) -> rs.getString("category"));
     }
 
     @Override

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -36,7 +36,7 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
         private int price;
         private boolean basic;
         private boolean colorCondition;
-        private Long trimInteriorColorId;
+        private String trimInteriorColorCode;
         private String hashTag;
         private Long hmgModelOptionId;
     }
@@ -97,9 +97,9 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
                 .build();
     }
 
-    private static List<Long> getTrimInteriorColorIds(List<TrimOptionQueryResult> trimOptionInfos) {
+    private static List<String> getTrimInteriorColorIds(List<TrimOptionQueryResult> trimOptionInfos) {
         return trimOptionInfos.stream()
-                .map(TrimOptionQueryResult::getTrimInteriorColorId)
+                .map(TrimOptionQueryResult::getTrimInteriorColorCode)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
@@ -126,7 +126,7 @@ public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository 
                 .price(rs.getInt("price"))
                 .basic(false)
                 .colorCondition(rs.getBoolean("colorCondition"))
-                .trimInteriorColorId(rs.getLong("trimInteriorColorId"))
+                .trimInteriorColorCode(rs.getString("trimInteriorColorCode"))
                 .hashTag(rs.getString("hashTag"))
                 .hmgModelOptionId(rs.getLong("hmgModelOptionId"));
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryImpl.java
@@ -1,0 +1,116 @@
+package softeer.wantcar.cartalog.trim.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+import softeer.wantcar.cartalog.global.ServerPath;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class TrimOptionQueryRepositoryImpl implements TrimOptionQueryRepository {
+    private final ServerPath serverPath;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    private static class TrimOptionQueryResult {
+        private Long id;
+        private String name;
+        private String parentCategory;
+        private String childCategory;
+        private String imageUrl;
+        private int price;
+        private boolean basic;
+        private boolean colorCondition;
+        private Long trimInteriorColorId;
+        private String hashTag;
+        private Long hmgModelOptionId;
+    }
+
+    @Override
+    public List<TrimOptionInfo> findOptionsByDetailTrimId(Long detailTrimId) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("detailTrimId", detailTrimId);
+        List<TrimOptionQueryResult> queryResults = jdbcTemplate.query(QueryString.findOptionsByDetailTrimId,
+                parameters, (rs, rowNum) -> getTrimOptionQueryResult(rs));
+        if(queryResults.isEmpty()) {
+            return null;
+        }
+
+        Map<Long, List<TrimOptionQueryResult>> trimOptionQueryResults = queryResults.stream()
+                .collect(Collectors.groupingBy(TrimOptionQueryResult::getId));
+
+        List<TrimOptionInfo> trimOptionInfos = new ArrayList<>();
+        for (Long detailTrimOptionId : trimOptionQueryResults.keySet()) {
+            trimOptionInfos.add(getTrimOptionInfo(detailTrimId, trimOptionQueryResults, detailTrimOptionId));
+        }
+        return trimOptionInfos;
+    }
+
+    private TrimOptionInfo getTrimOptionInfo(Long detailTrimId, Map<Long, List<TrimOptionQueryResult>> trimOptionQueryResults, Long detailTrimOptionId) {
+        List<TrimOptionQueryResult> optionQueryResults = trimOptionQueryResults.get(detailTrimOptionId);
+        TrimOptionQueryResult optionQueryResult = optionQueryResults.get(0);
+        return TrimOptionInfo.builder()
+                .id(detailTrimId)
+                .name(optionQueryResult.getName())
+                .parentCategory(optionQueryResult.parentCategory)
+                .childCategory(optionQueryResult.getChildCategory())
+                .imageUrl(serverPath.attachImageServerPath(optionQueryResult.getImageUrl()))
+                .price(optionQueryResult.getPrice())
+                .basic(optionQueryResult.isBasic())
+                .colorCondition(optionQueryResult.isColorCondition())
+                .trimInteriorColorIds(getTrimInteriorColorIds(optionQueryResults))
+                .hashTags(getOptionHasTags(optionQueryResults))
+                .hasHMGData(isOptionHasHmgData(optionQueryResults))
+                .build();
+    }
+
+    private static List<Long> getTrimInteriorColorIds(List<TrimOptionQueryResult> trimOptionInfos) {
+        return trimOptionInfos.stream()
+                .map(TrimOptionQueryResult::getTrimInteriorColorId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getOptionHasTags(List<TrimOptionQueryResult> trimOptionInfos) {
+        return trimOptionInfos.stream()
+                .map(TrimOptionQueryResult::getHashTag)
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isOptionHasHmgData(List<TrimOptionQueryResult> trimOptionInfos) {
+        return trimOptionInfos.stream()
+                .map(TrimOptionQueryResult::getHmgModelOptionId)
+                .anyMatch(Objects::nonNull);
+    }
+
+    private static TrimOptionQueryResult getTrimOptionQueryResult(ResultSet rs) throws SQLException {
+        return TrimOptionQueryResult.builder()
+                .id(rs.getLong("id"))
+                .name(rs.getString("name"))
+                .parentCategory(rs.getString("parentCategory"))
+                .childCategory(rs.getString("childCategory"))
+                .imageUrl(rs.getString("imageUrl"))
+                .price(rs.getInt("price"))
+                .basic(rs.getBoolean("basic"))
+                .colorCondition(rs.getBoolean("colorCondition"))
+                .trimInteriorColorId(rs.getLong("trimInteriorColorId"))
+                .hashTag(rs.getString("hashTag"))
+                .hmgModelOptionId(rs.getLong("hmgModelOptionId"))
+                .build();
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
@@ -3,5 +3,5 @@ package softeer.wantcar.cartalog.trim.service;
 import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 
 public interface TrimOptionService {
-    TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, Long interiorColorId);
+    TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, String interiorColorCode);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
@@ -1,0 +1,7 @@
+package softeer.wantcar.cartalog.trim.service;
+
+import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
+
+public interface TrimOptionService {
+    TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, Long interiorColorId);
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
@@ -1,0 +1,62 @@
+package softeer.wantcar.cartalog.trim.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
+import softeer.wantcar.cartalog.trim.repository.TrimOptionQueryRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto.*;
+
+@Service
+@RequiredArgsConstructor
+public class TrimOptionServiceImpl implements TrimOptionService {
+    private final TrimOptionQueryRepository trimOptionQueryRepository;
+
+    @Override
+    public TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, Long interiorColorId) {
+        List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectableCategories();
+        List<TrimOptionQueryRepository.TrimOptionInfo> options = trimOptionQueryRepository.findOptionsByDetailTrimId(detailTrimId);
+        List<TrimOptionQueryRepository.TrimOptionInfo> packages = trimOptionQueryRepository.findPackagesByDetailTrimId(detailTrimId);
+        if(Objects.isNull(options) || Objects.isNull(packages)) {
+            return null;
+        }
+
+        Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions = options.stream()
+                .filter(option -> filterColorCondition(interiorColorId, option))
+                .collect(Collectors.groupingBy(TrimOptionQueryRepository.TrimOptionInfo::isBasic));
+
+        return builder()
+                .multipleSelectParentCategory(multipleSelectableCategories)
+                .defaultOptions(getDefaultOptions(collectedOptions))
+                .selectOptions(getSelectableOptions(packages, collectedOptions))
+                .build();
+    }
+
+    private boolean filterColorCondition(Long interiorColorId, TrimOptionQueryRepository.TrimOptionInfo option) {
+        return !option.isColorCondition() || option.getTrimInteriorColorIds().contains(interiorColorId);
+    }
+
+    private List<TrimOptionDto> getDefaultOptions(Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
+        return getOptions(collectedOptions.getOrDefault(true, new ArrayList<>()));
+    }
+
+    private List<TrimOptionDto> getSelectableOptions(List<TrimOptionQueryRepository.TrimOptionInfo> packages,
+                                                     Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
+        List<TrimOptionDto> selectableOptions = getOptions(collectedOptions.getOrDefault(false, new ArrayList<>()));
+        List<TrimOptionDto> selectablePackages = getOptions(packages);
+        selectablePackages.addAll(selectableOptions);
+        return selectablePackages;
+    }
+
+    private List<TrimOptionDto> getOptions(List<TrimOptionQueryRepository.TrimOptionInfo> collectedOptions) {
+        return collectedOptions.stream()
+                .map(option -> new TrimOptionDto(option, 0))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
@@ -17,7 +17,7 @@ public class TrimOptionServiceImpl implements TrimOptionService {
     private final TrimOptionQueryRepository trimOptionQueryRepository;
 
     @Override
-    public TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, Long interiorColorId) {
+    public TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, String interiorColorCode) {
         List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectableCategories();
         List<TrimOptionQueryRepository.TrimOptionInfo> options = trimOptionQueryRepository.findOptionsByDetailTrimId(detailTrimId);
         List<TrimOptionQueryRepository.TrimOptionInfo> packages = trimOptionQueryRepository.findPackagesByDetailTrimId(detailTrimId);
@@ -26,7 +26,7 @@ public class TrimOptionServiceImpl implements TrimOptionService {
         }
 
         Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions = options.stream()
-                .filter(option -> filterColorCondition(interiorColorId, option))
+                .filter(option -> filterColorCondition(interiorColorCode, option))
                 .collect(Collectors.groupingBy(TrimOptionQueryRepository.TrimOptionInfo::isBasic));
 
         return TrimOptionListResponseDto.builder()
@@ -36,8 +36,8 @@ public class TrimOptionServiceImpl implements TrimOptionService {
                 .build();
     }
 
-    private boolean filterColorCondition(Long interiorColorId, TrimOptionQueryRepository.TrimOptionInfo option) {
-        return !option.isColorCondition() || option.getTrimInteriorColorIds().contains(interiorColorId);
+    private boolean filterColorCondition(String interiorColorCode, TrimOptionQueryRepository.TrimOptionInfo option) {
+        return !option.isColorCondition() || option.getTrimInteriorColorIds().contains(interiorColorCode);
     }
 
     private List<TrimOptionListResponseDto.TrimOptionDto> getDefaultOptions(Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceImpl.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto.*;
-
 @Service
 @RequiredArgsConstructor
 public class TrimOptionServiceImpl implements TrimOptionService {
@@ -23,7 +21,7 @@ public class TrimOptionServiceImpl implements TrimOptionService {
         List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectableCategories();
         List<TrimOptionQueryRepository.TrimOptionInfo> options = trimOptionQueryRepository.findOptionsByDetailTrimId(detailTrimId);
         List<TrimOptionQueryRepository.TrimOptionInfo> packages = trimOptionQueryRepository.findPackagesByDetailTrimId(detailTrimId);
-        if(Objects.isNull(options) || Objects.isNull(packages)) {
+        if (Objects.isNull(options) || Objects.isNull(packages)) {
             return null;
         }
 
@@ -31,7 +29,7 @@ public class TrimOptionServiceImpl implements TrimOptionService {
                 .filter(option -> filterColorCondition(interiorColorId, option))
                 .collect(Collectors.groupingBy(TrimOptionQueryRepository.TrimOptionInfo::isBasic));
 
-        return builder()
+        return TrimOptionListResponseDto.builder()
                 .multipleSelectParentCategory(multipleSelectableCategories)
                 .defaultOptions(getDefaultOptions(collectedOptions))
                 .selectOptions(getSelectableOptions(packages, collectedOptions))
@@ -42,21 +40,21 @@ public class TrimOptionServiceImpl implements TrimOptionService {
         return !option.isColorCondition() || option.getTrimInteriorColorIds().contains(interiorColorId);
     }
 
-    private List<TrimOptionDto> getDefaultOptions(Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
+    private List<TrimOptionListResponseDto.TrimOptionDto> getDefaultOptions(Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
         return getOptions(collectedOptions.getOrDefault(true, new ArrayList<>()));
     }
 
-    private List<TrimOptionDto> getSelectableOptions(List<TrimOptionQueryRepository.TrimOptionInfo> packages,
-                                                     Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
-        List<TrimOptionDto> selectableOptions = getOptions(collectedOptions.getOrDefault(false, new ArrayList<>()));
-        List<TrimOptionDto> selectablePackages = getOptions(packages);
+    private List<TrimOptionListResponseDto.TrimOptionDto> getSelectableOptions(List<TrimOptionQueryRepository.TrimOptionInfo> packages,
+                                                                               Map<Boolean, List<TrimOptionQueryRepository.TrimOptionInfo>> collectedOptions) {
+        List<TrimOptionListResponseDto.TrimOptionDto> selectableOptions = getOptions(collectedOptions.getOrDefault(false, new ArrayList<>()));
+        List<TrimOptionListResponseDto.TrimOptionDto> selectablePackages = getOptions(packages);
         selectablePackages.addAll(selectableOptions);
         return selectablePackages;
     }
 
-    private List<TrimOptionDto> getOptions(List<TrimOptionQueryRepository.TrimOptionInfo> collectedOptions) {
+    private List<TrimOptionListResponseDto.TrimOptionDto> getOptions(List<TrimOptionQueryRepository.TrimOptionInfo> collectedOptions) {
         return collectedOptions.stream()
-                .map(option -> new TrimOptionDto(option, 0))
+                .map(option -> new TrimOptionListResponseDto.TrimOptionDto(option, 0))
                 .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimQueryService.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimQueryService.java
@@ -7,7 +7,6 @@ import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
 import softeer.wantcar.cartalog.trim.dto.DetailTrimInfoDto;
 import softeer.wantcar.cartalog.trim.repository.TrimQueryRepository;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -28,7 +27,7 @@ public class TrimQueryService {
     }
 
     private static void checkCategoryOverlapped(List<String> categories, List<Long> modelTypeIds) {
-        if(categories.size() != modelTypeIds.size()) {
+        if (categories.size() != modelTypeIds.size()) {
             throw new IllegalArgumentException();
         }
     }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimColorControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimColorControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import softeer.wantcar.cartalog.global.ServerPaths;
 import softeer.wantcar.cartalog.trim.dto.TrimExteriorColorListResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimInteriorColorListResponseDto;
 import softeer.wantcar.cartalog.trim.repository.TrimColorQueryRepository;

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
@@ -46,11 +46,11 @@ public class TrimOptionControllerTest {
                     .defaultOptions(List.of(getTrimOptionDto("O1"), getTrimOptionDto("O2")))
                     .selectOptions(List.of(getTrimOptionDto("O3"), getTrimOptionDto("P1")))
                     .build();
-            when(trimOptionService.getTrimOptionList(1L, 1L))
+            when(trimOptionService.getTrimOptionList(1L, "AAA"))
                     .thenReturn(expectResponse);
 
             //when
-            ResponseEntity<TrimOptionListResponseDto> realResponse = trimOptionController.getOptionInfos(1L, 1L);
+            ResponseEntity<TrimOptionListResponseDto> realResponse = trimOptionController.getOptionInfos(1L, "AAA");
 
             //then
             assert realResponse != null;
@@ -63,10 +63,10 @@ public class TrimOptionControllerTest {
         @DisplayName("존재하지 않는 트림 식별자로 옵션 정보 목록 요청시 404 상태를 반환해야 한다")
         void returnStatusCode404WhenGetOptionInfoListBy() {
             //given
-            when(trimOptionService.getTrimOptionList(-1L, 1L))
+            when(trimOptionService.getTrimOptionList(-1L, "AAA"))
                     .thenReturn(null);
             //when
-            ResponseEntity<TrimOptionListResponseDto> response = trimOptionController.getOptionInfos(-1L, 1L);
+            ResponseEntity<TrimOptionListResponseDto> response = trimOptionController.getOptionInfos(-1L, "AAA");
 
             //then
             softAssertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
@@ -26,7 +26,6 @@ public class TrimOptionControllerTest {
     SoftAssertions softAssertions;
     TrimOptionController trimOptionController;
     TrimOptionService trimOptionService;
-    static String imageServerPath = "example-url";
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
@@ -44,14 +44,14 @@ public class TrimOptionControllerTest {
             softAssertions.assertThat(realResponse.getMultipleSelectParentCategory())
                     .containsAll(List.of("상세 품목", "악세사리"));
             softAssertions.assertThat(realResponse.getDefaultOptions())
-                    .contains(getTrimOptionDto(5L,
+                    .contains(getTrimOptionDto("O5",
                             "디젤 2.2 엔진",
                             null,
                             "파워트레인/성능",
                             "/palisade/le-blanc/options/dieselengine2.2_s.jpg",
                             0));
             softAssertions.assertThat(realResponse.getSelectOptions())
-                    .contains(getTrimOptionDto(11L,
+                    .contains(getTrimOptionDto("O11",
                             "2열 통풍시트",
                             "상세품목",
                             "시트",
@@ -188,7 +188,7 @@ public class TrimOptionControllerTest {
     }
 
     private static TrimOptionListResponseDto.TrimOptionDto getTrimOptionDto(
-            Long id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
+            String id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
         return TrimOptionListResponseDto.TrimOptionDto.builder()
                 .id(id)
                 .name(name)

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/controller/TrimOptionControllerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import softeer.wantcar.cartalog.global.dto.HMGDataDto;
@@ -18,7 +17,8 @@ import softeer.wantcar.cartalog.trim.service.TrimOptionService;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 @DisplayName("트림 옵션 도메인 테스트")
@@ -56,7 +56,7 @@ public class TrimOptionControllerTest {
             //then
             assert realResponse != null;
             softAssertions.assertThat(realResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-            softAssertions.assertThat(realResponse).isEqualTo(expectResponse);
+            softAssertions.assertThat(realResponse.getBody()).isEqualTo(expectResponse);
             softAssertions.assertAll();
         }
 
@@ -189,20 +189,6 @@ public class TrimOptionControllerTest {
             //then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
-    }
-
-    private static TrimOptionListResponseDto.TrimOptionDto getTrimOptionDto(
-            String id, String name, String parentCategory, String childCategory, String imageUrl, int price) {
-        return TrimOptionListResponseDto.TrimOptionDto.builder()
-                .id(id)
-                .name(name)
-                .parentCategory(parentCategory)
-                .childCategory(childCategory)
-                .imageUrl(imageServerPath + imageUrl)
-                .price(price)
-                .chosen(38)
-                .hashTags(List.of("장거리 운전"))
-                .build();
     }
 
     private static TrimOptionListResponseDto.TrimOptionDto getTrimOptionDto(String id) {

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImplTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
-import softeer.wantcar.cartalog.global.ServerPaths;
+import softeer.wantcar.cartalog.global.ServerPath;
 import softeer.wantcar.cartalog.trim.dto.TrimExteriorColorListResponseDto;
 import softeer.wantcar.cartalog.trim.dto.TrimInteriorColorListResponseDto;
 
@@ -24,12 +24,12 @@ class TrimColorQueryRepositoryImplTest {
     NamedParameterJdbcTemplate jdbcTemplate;
     TrimTestRepository trimQueryRepository;
     TrimColorQueryRepository trimColorQueryRepository;
-    ServerPaths serverPaths = new ServerPaths();
+    ServerPath serverPath = new ServerPath();
     SoftAssertions softAssertions;
 
     @BeforeEach
     void setUp() {
-        trimColorQueryRepository = new TrimColorQueryRepositoryImpl(serverPaths, jdbcTemplate);
+        trimColorQueryRepository = new TrimColorQueryRepositoryImpl(serverPath, jdbcTemplate);
         trimQueryRepository = new TrimTestRepository(jdbcTemplate);
         softAssertions = new SoftAssertions();
     }
@@ -50,7 +50,7 @@ class TrimColorQueryRepositoryImplTest {
             //then
             softAssertions.assertThat(result.getExteriorColors().size()).isEqualTo(6);
             softAssertions.assertThat(result.hasColor(selectableLeBlancExteriorColors)).isTrue();
-            softAssertions.assertThat(result.startWithUrl(serverPaths.IMAGE_SERVER_PATH)).isTrue();
+            softAssertions.assertThat(result.startWithUrl(serverPath.IMAGE_SERVER_PATH)).isTrue();
             softAssertions.assertAll();
         }
 
@@ -85,7 +85,7 @@ class TrimColorQueryRepositoryImplTest {
             //then
             softAssertions.assertThat(result.getInteriorColors().size()).isEqualTo(2);
             softAssertions.assertThat(result.hasColor(selectableInteriorColors)).isTrue();
-            softAssertions.assertThat(result.startWithUrl(serverPaths.IMAGE_SERVER_PATH)).isTrue();
+            softAssertions.assertThat(result.startWithUrl(serverPath.IMAGE_SERVER_PATH)).isTrue();
             softAssertions.assertAll();
         }
 

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimColorQueryRepositoryImplTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 @Sql({"classpath:schema.sql"})
+@DisplayName("트림 색상 Repository 테스트")
 class TrimColorQueryRepositoryImplTest {
     @Autowired
     NamedParameterJdbcTemplate jdbcTemplate;

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -1,0 +1,77 @@
+package softeer.wantcar.cartalog.trim.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import softeer.wantcar.cartalog.global.ServerPaths;
+import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+@Sql({"classpath:schema.sql"})
+class TrimOptionQueryRepositoryTest {
+    @Autowired
+    NamedParameterJdbcTemplate jdbcTemplate;
+    TrimOptionQueryRepository trimOptionQueryRepository;
+    ServerPaths serverPaths = new ServerPaths();
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setUp() {
+        trimOptionQueryRepository = new TrimOptionQueryRepositoryImpl(jdbcTemplate);
+        softAssertions = new SoftAssertions();
+    }
+
+    @SuppressWarnings({"SqlNoDataSourceInspection", "SqlResolve"})
+    @Nested
+    @DisplayName("트림 옵션 목록 조회 테스트")
+    class getTrimOptionListTest {
+        @Test
+        @DisplayName("존재하는 세부 트림 식별자라면 트림 옵션 목록을 리스트로 반환한다")
+        void returnTrimOptionListWhenDetailTrimIdExist() {
+            //given
+            Long leblancDetailTrimId = jdbcTemplate.queryForObject(
+                    "SELECT " +
+                    "   dt.id " +
+                    "   FROM detail_trims AS dt " +
+                    "   JOIN trims AS t ON t.id=dt.trim_id " +
+                    "   WHERE t.name= 'Le Blanc' " +
+                    "   LIMIT 1",
+                    new HashMap<>(), Long.TYPE);
+
+            //when
+            List<TrimOptionListResponseDto.TrimOptionDto> trimOptions
+                    = trimOptionQueryRepository.findOptionsByDetailTrimId(leblancDetailTrimId);
+
+            softAssertions.assertThat(trimOptions.isEmpty()).isFalse();
+            softAssertions.assertThat(trimOptions.size()).isEqualTo(111);
+            for (TrimOptionListResponseDto.TrimOptionDto trimOption : trimOptions) {
+                softAssertions.assertThat(trimOption.getImageUrl()).startsWith(serverPaths.IMAGE_SERVER_PATH);
+            }
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 세부 트림 식별자라면 null을 반환한다")
+        void returnNullWhenDetailTrimIdNotExist() {
+            //given
+            Long notExistDetailTrimId = -1L;
+
+            //when
+            List<TrimOptionListResponseDto.TrimOptionDto> trimOptions
+                    = trimOptionQueryRepository.findOptionsByDetailTrimId(leblancDetailTrimId);
+
+            assertThat(trimOptions).isNull();
+        }
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -86,10 +86,10 @@ class TrimOptionQueryRepositoryTest {
             Long leblancDetailTrimId = jdbcTemplate.queryForObject(
                     "SELECT " +
                     "   dt.id " +
-                    "   FROM detail_trims AS dt " +
-                    "   JOIN trims AS t ON t.id=dt.trim_id " +
-                    "   WHERE t.name= 'Le Blanc' " +
-                    "   LIMIT 1",
+                    "FROM detail_trims AS dt " +
+                    "JOIN trims AS t ON t.id=dt.trim_id " +
+                    "WHERE t.name= 'Le Blanc' " +
+                    "LIMIT 1",
                     new HashMap<>(), Long.TYPE);
 
             //when

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 @Sql({"classpath:schema.sql"})
+@DisplayName("트림 옵션 Repository 테스트")
 class TrimOptionQueryRepositoryTest {
     @Autowired
     NamedParameterJdbcTemplate jdbcTemplate;
@@ -54,7 +55,7 @@ class TrimOptionQueryRepositoryTest {
 
             softAssertions.assertThat(trimOptions.isEmpty()).isFalse();
             for (TrimOptionQueryRepository.TrimOptionInfo trimOption : trimOptions) {
-                softAssertions.assertThat(trimOption.getId()).isGreaterThanOrEqualTo(1);
+                softAssertions.assertThat(trimOption.getId()).startsWith("O");
                 softAssertions.assertThat(trimOption.getImageUrl()).startsWith(serverPath.IMAGE_SERVER_PATH);
             }
             softAssertions.assertAll();
@@ -97,7 +98,7 @@ class TrimOptionQueryRepositoryTest {
 
             softAssertions.assertThat(trimPackages.isEmpty()).isFalse();
             for (TrimOptionQueryRepository.TrimOptionInfo trimPackage : trimPackages) {
-                softAssertions.assertThat(trimPackage.getId()).isGreaterThanOrEqualTo(1);
+                softAssertions.assertThat(trimPackage.getId()).startsWith("P");
                 softAssertions.assertThat(trimPackage.getImageUrl()).startsWith(serverPath.IMAGE_SERVER_PATH);
             }
             softAssertions.assertAll();

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
-import softeer.wantcar.cartalog.global.ServerPaths;
+import softeer.wantcar.cartalog.global.ServerPath;
 import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 
 import java.util.HashMap;
@@ -23,7 +23,7 @@ class TrimOptionQueryRepositoryTest {
     @Autowired
     NamedParameterJdbcTemplate jdbcTemplate;
     TrimOptionQueryRepository trimOptionQueryRepository;
-    ServerPaths serverPaths = new ServerPaths();
+    ServerPath serverPath = new ServerPath();
     SoftAssertions softAssertions;
 
     @BeforeEach
@@ -56,7 +56,7 @@ class TrimOptionQueryRepositoryTest {
             softAssertions.assertThat(trimOptions.isEmpty()).isFalse();
             softAssertions.assertThat(trimOptions.size()).isEqualTo(111);
             for (TrimOptionListResponseDto.TrimOptionDto trimOption : trimOptions) {
-                softAssertions.assertThat(trimOption.getImageUrl()).startsWith(serverPaths.IMAGE_SERVER_PATH);
+                softAssertions.assertThat(trimOption.getImageUrl()).startsWith(serverPath.IMAGE_SERVER_PATH);
             }
             softAssertions.assertAll();
         }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -116,4 +116,19 @@ class TrimOptionQueryRepositoryTest {
             assertThat(trimPackages).isNull();
         }
     }
+
+    @Nested
+    @DisplayName("복수 선택 가능 카테고리 목록 조회 테스트")
+    class getMultipleSelectableCategoryListTest {
+        @Test
+        @DisplayName("복수 선택 가능 카테고리 목록을 반환한다")
+        void returnMultipleSelectableCategoryList() {
+            //given
+            //when
+            List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectCategories();
+
+            //then
+            assertThat(multipleSelectableCategories).containsAll(List.of("상세품목", "악세서리"));
+        }
+    }
 }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -128,7 +128,7 @@ class TrimOptionQueryRepositoryTest {
             List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectCategories();
 
             //then
-            assertThat(multipleSelectableCategories).containsAll(List.of("상세품목", "악세서리"));
+            assertThat(multipleSelectableCategories).containsAll(List.of("상세품목", "악세사리"));
         }
     }
 }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -73,4 +73,47 @@ class TrimOptionQueryRepositoryTest {
             assertThat(trimOptions).isNull();
         }
     }
+
+    @SuppressWarnings({"SqlNoDataSourceInspection", "SqlResolve"})
+    @Nested
+    @DisplayName("트림 패키지 목록 조회 테스트")
+    class getTrimPackageListTest {
+        @Test
+        @DisplayName("존재하는 세부 트림 식별자라면 트림 패키지 목록을 리스트로 반환한다")
+        void returnTrimPackageListWhenDetailTrimIdExist() {
+            //given
+            Long leblancDetailTrimId = jdbcTemplate.queryForObject(
+                    "SELECT " +
+                    "   dt.id " +
+                    "   FROM detail_trims AS dt " +
+                    "   JOIN trims AS t ON t.id=dt.trim_id " +
+                    "   WHERE t.name= 'Le Blanc' " +
+                    "   LIMIT 1",
+                    new HashMap<>(), Long.TYPE);
+
+            //when
+            List<TrimOptionQueryRepository.TrimOptionInfo> trimPackages
+                    = trimOptionQueryRepository.findPackagesByDetailTrimId(leblancDetailTrimId);
+
+            softAssertions.assertThat(trimPackages.isEmpty()).isFalse();
+            for (TrimOptionQueryRepository.TrimOptionInfo trimPackage : trimPackages) {
+                softAssertions.assertThat(trimPackage.getId()).isGreaterThanOrEqualTo(1);
+                softAssertions.assertThat(trimPackage.getImageUrl()).startsWith(serverPath.IMAGE_SERVER_PATH);
+            }
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 세부 트림 식별자라면 null을 반환한다")
+        void returnNullWhenDetailTrimIdNotExist() {
+            //given
+            Long notExistDetailTrimId = -1L;
+
+            //when
+            List<TrimOptionQueryRepository.TrimOptionInfo> trimPackages
+                    = trimOptionQueryRepository.findPackagesByDetailTrimId(notExistDetailTrimId);
+
+            assertThat(trimPackages).isNull();
+        }
+    }
 }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -126,7 +126,7 @@ class TrimOptionQueryRepositoryTest {
         void returnMultipleSelectableCategoryList() {
             //given
             //when
-            List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectCategories();
+            List<String> multipleSelectableCategories = trimOptionQueryRepository.findMultipleSelectableCategories();
 
             //then
             assertThat(multipleSelectableCategories).containsAll(List.of("상세품목", "악세사리"));

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -43,10 +43,10 @@ class TrimOptionQueryRepositoryTest {
             Long leblancDetailTrimId = jdbcTemplate.queryForObject(
                     "SELECT " +
                     "   dt.id " +
-                    "   FROM detail_trims AS dt " +
-                    "   JOIN trims AS t ON t.id=dt.trim_id " +
-                    "   WHERE t.name= 'Le Blanc' " +
-                    "   LIMIT 1",
+                    "FROM detail_trims AS dt " +
+                    "JOIN trims AS t ON t.id=dt.trim_id " +
+                    "WHERE t.name= 'Le Blanc' " +
+                    "LIMIT 1",
                     new HashMap<>(), Long.TYPE);
 
             //when

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimOptionQueryRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import softeer.wantcar.cartalog.global.ServerPath;
-import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +27,7 @@ class TrimOptionQueryRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        trimOptionQueryRepository = new TrimOptionQueryRepositoryImpl(jdbcTemplate);
+        trimOptionQueryRepository = new TrimOptionQueryRepositoryImpl(serverPath, jdbcTemplate);
         softAssertions = new SoftAssertions();
     }
 
@@ -50,12 +49,12 @@ class TrimOptionQueryRepositoryTest {
                     new HashMap<>(), Long.TYPE);
 
             //when
-            List<TrimOptionListResponseDto.TrimOptionDto> trimOptions
+            List<TrimOptionQueryRepository.TrimOptionInfo> trimOptions
                     = trimOptionQueryRepository.findOptionsByDetailTrimId(leblancDetailTrimId);
 
             softAssertions.assertThat(trimOptions.isEmpty()).isFalse();
-            softAssertions.assertThat(trimOptions.size()).isEqualTo(111);
-            for (TrimOptionListResponseDto.TrimOptionDto trimOption : trimOptions) {
+            for (TrimOptionQueryRepository.TrimOptionInfo trimOption : trimOptions) {
+                softAssertions.assertThat(trimOption.getId()).isGreaterThanOrEqualTo(1);
                 softAssertions.assertThat(trimOption.getImageUrl()).startsWith(serverPath.IMAGE_SERVER_PATH);
             }
             softAssertions.assertAll();
@@ -68,8 +67,8 @@ class TrimOptionQueryRepositoryTest {
             Long notExistDetailTrimId = -1L;
 
             //when
-            List<TrimOptionListResponseDto.TrimOptionDto> trimOptions
-                    = trimOptionQueryRepository.findOptionsByDetailTrimId(leblancDetailTrimId);
+            List<TrimOptionQueryRepository.TrimOptionInfo> trimOptions
+                    = trimOptionQueryRepository.findOptionsByDetailTrimId(notExistDetailTrimId);
 
             assertThat(trimOptions).isNull();
         }

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/repository/TrimQueryRepositoryTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 @Sql({"classpath:schema.sql"})
+@DisplayName("트림 Repository 테스트")
 class TrimQueryRepositoryTest {
     @Value("${env.imageServerPath}")
     String imageServerPath = "example-url";

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
@@ -36,7 +36,7 @@ class TrimOptionServiceTest {
         @DisplayName("존재하는 세부 트림 식별자와 내부 색상 아이디를 전달한다면 그에 맞는 옵션 목록 Dto를 반환한다")
         void returnOptionListDto() {
             //given
-            when(trimOptionQueryRepository.findMultipleSelectCategories())
+            when(trimOptionQueryRepository.findMultipleSelectableCategories())
                     .thenReturn(List.of("A", "B", "C"));
             when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
                     .thenReturn(List.of(
@@ -60,7 +60,7 @@ class TrimOptionServiceTest {
         @DisplayName("적합한 입력일 때 주어진 색상이 옵션의 색상 조건에 해당되지 않는다면 해당 옵션을 목록에서 제외한다")
         void excludeOptionByColorCondition() {
             //given
-            when(trimOptionQueryRepository.findMultipleSelectCategories())
+            when(trimOptionQueryRepository.findMultipleSelectableCategories())
                     .thenReturn(List.of("A", "B", "C"));
             when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
                     .thenReturn(List.of(
@@ -82,7 +82,7 @@ class TrimOptionServiceTest {
         @DisplayName("세부 트림 식별자가 존재하지 않는 경우 null을 반환한다")
         void returnNull() {
             //given
-            when(trimOptionQueryRepository.findMultipleSelectCategories())
+            when(trimOptionQueryRepository.findMultipleSelectableCategories())
                     .thenReturn(List.of("A", "B", "C"));
             when(trimOptionQueryRepository.findOptionsByDetailTrimId(-1L))
                     .thenReturn(null);
@@ -107,7 +107,7 @@ class TrimOptionServiceTest {
                 .price(0)
                 .basic(basic)
                 .colorCondition(!Objects.isNull(trimInteriorColorId))
-                .trimInteriorColorIds(List.of(trimInteriorColorId))
+                .trimInteriorColorIds(Objects.isNull(trimInteriorColorId) ? new ArrayList<>() : List.of(trimInteriorColorId))
                 .hashTags(new ArrayList<>())
                 .hasHMGData(false)
                 .build();

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
@@ -1,0 +1,115 @@
+package softeer.wantcar.cartalog.trim.service;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import softeer.wantcar.cartalog.trim.dto.TrimOptionListResponseDto;
+import softeer.wantcar.cartalog.trim.repository.TrimOptionQueryRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("트림 옵션 서비스 테스트")
+class TrimOptionServiceTest {
+    TrimOptionService trimOptionService;
+    TrimOptionQueryRepository trimOptionQueryRepository;
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setUp() {
+        trimOptionQueryRepository = mock(TrimOptionQueryRepository.class);
+        trimOptionService = new TrimOptionServiceImpl(trimOptionQueryRepository);
+        softAssertions = new SoftAssertions();
+    }
+
+    @Nested
+    @DisplayName("트림 옵션 목록 조회 테스트")
+    class getTrimOptionListTest {
+        @Test
+        @DisplayName("존재하는 세부 트림 식별자와 내부 색상 아이디를 전달한다면 그에 맞는 옵션 목록 Dto를 반환한다")
+        void returnOptionListDto() {
+            //given
+            when(trimOptionQueryRepository.findMultipleSelectCategories())
+                    .thenReturn(List.of("A", "B", "C"));
+            when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
+                    .thenReturn(List.of(
+                            getTrimOptionInfo("O1", true, 1L),
+                            getTrimOptionInfo("O2", false, null)));
+            when(trimOptionQueryRepository.findPackagesByDetailTrimId(1L))
+                    .thenReturn(List.of(getTrimOptionInfo("P1", false, 1L)));
+
+            //when
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(1L, 1L);
+
+            //then
+            softAssertions.assertThat(responseDto.getMultipleSelectParentCategory())
+                    .containsAll(List.of("A", "B", "C"));
+            softAssertions.assertThat(responseDto.getDefaultOptions().size()).isEqualTo(1);
+            softAssertions.assertThat(responseDto.getSelectOptions().size()).isEqualTo(2);
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("적합한 입력일 때 주어진 색상이 옵션의 색상 조건에 해당되지 않는다면 해당 옵션을 목록에서 제외한다")
+        void excludeOptionByColorCondition() {
+            //given
+            when(trimOptionQueryRepository.findMultipleSelectCategories())
+                    .thenReturn(List.of("A", "B", "C"));
+            when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
+                    .thenReturn(List.of(
+                            getTrimOptionInfo("O1", true, 1L),
+                            getTrimOptionInfo("O2", false, 1L)));
+            when(trimOptionQueryRepository.findPackagesByDetailTrimId(1L))
+                    .thenReturn(List.of(getTrimOptionInfo("P1", false, 1L)));
+
+            //when
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, 2L);
+
+            //then
+            softAssertions.assertThat(responseDto.getDefaultOptions().isEmpty()).isTrue();
+            softAssertions.assertThat(responseDto.getSelectOptions().isEmpty()).isTrue();
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("세부 트림 식별자가 존재하지 않는 경우 null을 반환한다")
+        void returnNull() {
+            //given
+            when(trimOptionQueryRepository.findMultipleSelectCategories())
+                    .thenReturn(List.of("A", "B", "C"));
+            when(trimOptionQueryRepository.findOptionsByDetailTrimId(-1L))
+                    .thenReturn(null);
+            when(trimOptionQueryRepository.findPackagesByDetailTrimId(-1L))
+                    .thenReturn(null);
+
+            //when
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, 1L);
+
+            //then
+            assertThat(responseDto).isNull();
+        }
+    }
+
+    private static TrimOptionQueryRepository.TrimOptionInfo getTrimOptionInfo(String id, boolean basic, Long trimInteriorColorId) {
+        return TrimOptionQueryRepository.TrimOptionInfo.builder()
+                .id(id)
+                .name(id)
+                .parentCategory("A")
+                .childCategory("a")
+                .imageUrl("image")
+                .price(0)
+                .basic(basic)
+                .colorCondition(!Objects.isNull(trimInteriorColorId))
+                .trimInteriorColorIds(List.of(trimInteriorColorId))
+                .hashTags(new ArrayList<>())
+                .hasHMGData(false)
+                .build();
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/trim/service/TrimOptionServiceTest.java
@@ -40,13 +40,13 @@ class TrimOptionServiceTest {
                     .thenReturn(List.of("A", "B", "C"));
             when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
                     .thenReturn(List.of(
-                            getTrimOptionInfo("O1", true, 1L),
+                            getTrimOptionInfo("O1", true, "AAA"),
                             getTrimOptionInfo("O2", false, null)));
             when(trimOptionQueryRepository.findPackagesByDetailTrimId(1L))
-                    .thenReturn(List.of(getTrimOptionInfo("P1", false, 1L)));
+                    .thenReturn(List.of(getTrimOptionInfo("P1", false, "AAA")));
 
             //when
-            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(1L, 1L);
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(1L, "AAA");
 
             //then
             softAssertions.assertThat(responseDto.getMultipleSelectParentCategory())
@@ -64,13 +64,13 @@ class TrimOptionServiceTest {
                     .thenReturn(List.of("A", "B", "C"));
             when(trimOptionQueryRepository.findOptionsByDetailTrimId(1L))
                     .thenReturn(List.of(
-                            getTrimOptionInfo("O1", true, 1L),
-                            getTrimOptionInfo("O2", false, 1L)));
+                            getTrimOptionInfo("O1", true, "BBB"),
+                            getTrimOptionInfo("O2", false, "BBB")));
             when(trimOptionQueryRepository.findPackagesByDetailTrimId(1L))
-                    .thenReturn(List.of(getTrimOptionInfo("P1", false, 1L)));
+                    .thenReturn(List.of(getTrimOptionInfo("P1", false, "BBB")));
 
             //when
-            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, 2L);
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, "AAA");
 
             //then
             softAssertions.assertThat(responseDto.getDefaultOptions().isEmpty()).isTrue();
@@ -90,14 +90,14 @@ class TrimOptionServiceTest {
                     .thenReturn(null);
 
             //when
-            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, 1L);
+            TrimOptionListResponseDto responseDto = trimOptionService.getTrimOptionList(-1L, "AAA");
 
             //then
             assertThat(responseDto).isNull();
         }
     }
 
-    private static TrimOptionQueryRepository.TrimOptionInfo getTrimOptionInfo(String id, boolean basic, Long trimInteriorColorId) {
+    private static TrimOptionQueryRepository.TrimOptionInfo getTrimOptionInfo(String id, boolean basic, String trimInteriorColorId) {
         return TrimOptionQueryRepository.TrimOptionInfo.builder()
                 .id(id)
                 .name(id)

--- a/backend/src/test/resources/csv/model_option_parent_categories.csv
+++ b/backend/src/test/resources/csv/model_option_parent_categories.csv
@@ -1,4 +1,4 @@
-category
-상세품목
-악세사리
-휠
+category|multiple_select
+상세품목|true
+악세사리|true
+휠|false

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -31,7 +31,8 @@ CREATE TABLE basic_model_categories
 
 CREATE TABLE model_option_parent_categories
 (
-    category VARCHAR(255) PRIMARY KEY
+    category VARCHAR(255) PRIMARY KEY,
+    multiple_select BOOLEAN NOT NULL
 );
 
 CREATE TABLE model_option_child_categories
@@ -248,7 +249,7 @@ INSERT INTO basic_model_categories (category)
 SELECT *
 FROM CSVREAD('classpath:csv/basic_model_categories.csv', null, 'fieldSeparator=|');
 
-INSERT INTO model_option_parent_categories (category)
+INSERT INTO model_option_parent_categories (category, multiple_select)
 SELECT *
 FROM CSVREAD('classpath:csv/model_option_parent_categories.csv', null, 'fieldSeparator=|');
 


### PR DESCRIPTION
## 한 일
- [x] API 명세에 맞게 실제 옵션 정보 목록 조회 API 구현
- [x] Swagger에 API 설명 추가

## 주의사항
- [ ] Merge하기 전에 운영 데이터베이스의 테이블 업데이트가 필요합니다.

close #116 