### PR TITLE
[Front-End] feat: useIntersectionObserver 훅 추가

### DIFF
--- a/frontend/src/hooks/useIntersectionObserver.js
+++ b/frontend/src/hooks/useIntersectionObserver.js
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useIntersectionObserver = (targetRef) => {
+  const [isInViewport, setIsInViewport] = useState(false);
+  const observerRef = useRef();
+
+  useEffect(() => {
+    const observerCallback = (entries) => {
+      setIsInViewport(entries[0].isIntersecting);
+    };
+
+    if (!observerRef.current) {
+      observerRef.current = new window.IntersectionObserver(observerCallback, {
+        threshold: 0,
+      });
+    }
+
+    if (targetRef.current) {
+      observerRef.current.observe(targetRef.current);
+    }
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, [targetRef]);
+
+  return isInViewport;
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
# Changes

* useIntersectionObserver 훅 추가

> 컴포넌트가 화면에 보이는지 감지해서 화면에 보일 때 애니메이션을 시작할 수 있음

# Usage

```javascript
function SampleComponent({ children }) {
  const targetRef = useRef();
  const isInViewport = useIntersectionObserver(targetRef);
  const className = isInViewport ? 'rendered' : '';

  return <div className={className} ref={targetRef}>{children}</div>;
}
```

# Related Issues

* Close #266 