### PR TITLE
[Backend] 모델 타입 옵션 쿼리 수정

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
@@ -32,7 +32,7 @@ public class ModelController {
             @ApiResponse(code = 500, message = "적절하지 않은 데이터가 있어 요청을 처리할 수 없습니다. 관리자에게 문의하세요.")})
     @GetMapping("/types")
     public ResponseEntity<ModelTypeListResponseDto> searchModelType(@PathParam("trimId") Long trimId) {
-        ModelTypeListResponseDto dto = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId);
+        ModelTypeListResponseDto dto = modelOptionQueryRepository.findByModelTypeOptionsByTrimId(trimId);
 
         if (dto == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
@@ -27,14 +27,14 @@ public class ModelController {
             value = "모델 타입 조회",
             notes = "모델에서 사용가능한 모델 옵션과 세부 정보를 조회한다.")
     @ApiImplicitParam(
-            name = "basicModelId", value = "기초 모델 식별자", required = true,
+            name = "trimId", value = "트림 식별자", required = true,
             dataType = "java.lang.Long", paramType = "query", example = "1")
     @ApiResponses({
             @ApiResponse(code = 404, message = "존재하지 않는 식별자입니다."),
             @ApiResponse(code = 500, message = "적절하지 않은 데이터가 있어 요청을 처리할 수 없습니다. 관리자에게 문의하세요.")})
     @GetMapping("/types")
-    public ResponseEntity<ModelTypeListResponseDto> searchModelType(@PathParam("basicModelId") Long basicModelId) {
-        ModelTypeListResponseDto dto = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(basicModelId);
+    public ResponseEntity<ModelTypeListResponseDto> searchModelType(@PathParam("trimId") Long trimId) {
+        ModelTypeListResponseDto dto = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId);
 
         if (dto == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
@@ -1,9 +1,6 @@
 package softeer.wantcar.cartalog.model.controller;
 
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -16,10 +13,11 @@ import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
 
 import javax.websocket.server.PathParam;
 
-@Slf4j
+@Api(tags = {"모델 관련 API"})
 @RestController
 @RequestMapping("/models")
 @RequiredArgsConstructor
+@Slf4j
 public class ModelController {
     private final ModelOptionQueryRepository modelOptionQueryRepository;
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ModelOptionQueryRepository {
 
-    ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long id);
+    ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long trimId);
 
     List<String> findModelTypeCategoriesByIds(List<Long> modelTypeIds);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ModelOptionQueryRepository {
 
-    ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long trimId);
+    ModelTypeListResponseDto findByModelTypeOptionsByTrimId(Long trimId);
 
     List<String> findModelTypeCategoriesByIds(List<Long> modelTypeIds);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
@@ -73,25 +73,29 @@ public class ModelOptionQueryRepositoryImpl implements ModelOptionQueryRepositor
 
     @Override
     @Transactional(readOnly = true)
-    public ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long basicModelId) {
-        String SQL = "SELECT " +
-                     "  model_options.id AS model_option_id, " +
-                     "  model_options.name, " +
-                     "  child_category, " +
-                     "  image_url, " +
-                     "  description, " +
-                     "  hmg_data.name AS hmg_data_name, " +
-                     "  hmg_data.val AS hmg_data_value, " +
-                     "  hmg_data.measure AS hmg_data_measure, " +
-                     "  price_if_model_type_option AS price " +
-                     "FROM model_options " +
-                     "LEFT JOIN hmg_data " +
-                     "ON model_options.id = hmg_data.model_option_id " +
-                     "WHERE model_id = :basicModelId " +
-                     "  AND price_if_model_type_option IS NOT NULL";
+    public ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long trimId) {
+        String SQL = "SELECT DISTINCT mo.id                         AS model_option_id, " +
+                     "                mo.name                       AS name, " +
+                     "                mo.child_category             AS child_category, " +
+                     "                mo.image_url                  AS image_url, " +
+                     "                mo.description                AS description, " +
+                     "                mo.price_if_model_type_option AS price, " +
+                     "                hmg.name                      AS hmg_data_name, " +
+                     "                hmg.val                       AS hmg_data_value, " +
+                     "                hmg.measure                   AS hmg_data_measure " +
+                     "FROM   detail_model_decision_options AS dmdo " +
+                     "       JOIN detail_models AS dm " +
+                     "         ON dm.id = dmdo.detail_model_id " +
+                     "       JOIN detail_trims AS dt " +
+                     "         ON dt.detail_model_id = dm.id " +
+                     "       JOIN model_options AS mo " +
+                     "         ON mo.id = dmdo.model_option_id " +
+                     "       LEFT OUTER JOIN hmg_data AS hmg " +
+                     "                    ON mo.id = hmg.model_option_id " +
+                     "WHERE  dt.trim_id = :trimId; ";
 
         SqlParameterSource parameters = new MapSqlParameterSource()
-                .addValue("basicModelId", basicModelId);
+                .addValue("trimId", trimId);
 
         List<SimpleModelOptionMapper> simpleModelOptionMapperList = jdbcTemplate.query(SQL, parameters,
                 (rs, rowNum) -> SimpleModelOptionMapper.builder()

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
@@ -73,7 +73,7 @@ public class ModelOptionQueryRepositoryImpl implements ModelOptionQueryRepositor
 
     @Override
     @Transactional(readOnly = true)
-    public ModelTypeListResponseDto findByModelTypeOptionsByBasicModelId(Long trimId) {
+    public ModelTypeListResponseDto findByModelTypeOptionsByTrimId(Long trimId) {
         String SQL = "SELECT DISTINCT mo.id                         AS model_option_id, " +
                      "                mo.name                       AS name, " +
                      "                mo.child_category             AS child_category, " +

--- a/backend/src/test/java/softeer/wantcar/cartalog/CartalogApplicationTests.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/CartalogApplicationTests.java
@@ -10,4 +10,4 @@ class CartalogApplicationTests {
     @Test
     void contextLoads() {
     }
-}
+}   

--- a/backend/src/test/java/softeer/wantcar/cartalog/CartalogApplicationTests.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/CartalogApplicationTests.java
@@ -10,4 +10,4 @@ class CartalogApplicationTests {
     @Test
     void contextLoads() {
     }
-}   
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/controller/ModelControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/controller/ModelControllerTest.java
@@ -35,15 +35,15 @@ class ModelControllerTest {
     @DisplayName("모델타입 목록 조회 테스트")
     class getModelTypeListTest {
         @Test
-        @DisplayName("올바른 요청시 200 상태와 함께 모델 식별자에 해당하는 모델의 모델 타입 리스트를 반환한다.")
+        @DisplayName("올바른 요청시 200 상태와 함께 트림 식별자에 해당하는 모델의 모델 타입 리스트를 반환한다.")
         void returnDtoHasModelTypeOfBasicModelIdWhenGetModelTypeByExistBasicModelId() {
             //given
-            Long basicModelId = 1L;
+            Long trimId = 2L;
             ModelTypeListResponseDto returnDto = mock(ModelTypeListResponseDto.class);
-            when(modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(basicModelId)).thenReturn(returnDto);
+            when(modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId)).thenReturn(returnDto);
 
             //when
-            ResponseEntity<ModelTypeListResponseDto> response = modelController.searchModelType(basicModelId);
+            ResponseEntity<ModelTypeListResponseDto> response = modelController.searchModelType(trimId);
 
             //then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -52,7 +52,7 @@ class ModelControllerTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 모델의 식별자로 조회할 경우 404 상태를 반환해야 한다.")
+        @DisplayName("존재하지 않는 트림 식별자로 조회할 경우 404 상태를 반환해야 한다.")
         void returnStatusCode404WhenGetModelTypeByExistModelId() {
             //given
             Long basicModelId = -1L;

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/controller/ModelControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/controller/ModelControllerTest.java
@@ -40,7 +40,7 @@ class ModelControllerTest {
             //given
             Long trimId = 2L;
             ModelTypeListResponseDto returnDto = mock(ModelTypeListResponseDto.class);
-            when(modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId)).thenReturn(returnDto);
+            when(modelOptionQueryRepository.findByModelTypeOptionsByTrimId(trimId)).thenReturn(returnDto);
 
             //when
             ResponseEntity<ModelTypeListResponseDto> response = modelController.searchModelType(trimId);
@@ -56,7 +56,7 @@ class ModelControllerTest {
         void returnStatusCode404WhenGetModelTypeByExistModelId() {
             //given
             Long basicModelId = -1L;
-            when(modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(basicModelId)).thenReturn(null);
+            when(modelOptionQueryRepository.findByModelTypeOptionsByTrimId(basicModelId)).thenReturn(null);
 
             //when
             ResponseEntity<ModelTypeListResponseDto> response = modelController.searchModelType(basicModelId);

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
@@ -50,7 +50,7 @@ class ModelOptionQueryRepositoryImplTest {
             checkOptions.put("구동방식", List.of("2WD", "4WD"));
 
             //when
-            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId);
+            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByTrimId(trimId);
 
             //then
             assertThat(response).isNotNull();
@@ -69,7 +69,7 @@ class ModelOptionQueryRepositoryImplTest {
             Long basicModelId = -1L;
 
             //when
-            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(basicModelId);
+            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByTrimId(basicModelId);
 
             //then
             assertThat(response).isNull();

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
@@ -42,7 +42,7 @@ class ModelOptionQueryRepositoryImplTest {
         @DisplayName("존재하는 식별자로 조회시 모델 타입 옵션을 포함한 dto를 반환해야 한다.")
         void findByModelTypeOptionsByBasicModelIdWithCollectId() {
             //given
-            Long basicModelId = 1L;
+            Long trimId = 2L;
             List<String> checkTypes = List.of("파워트레인/성능", "바디타입", "구동방식");
             Map<String, List<String>> checkOptions = new HashMap<>();
             checkOptions.put("파워트레인/성능", List.of("디젤 2.2", "가솔린 3.8"));
@@ -50,7 +50,7 @@ class ModelOptionQueryRepositoryImplTest {
             checkOptions.put("구동방식", List.of("2WD", "4WD"));
 
             //when
-            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(basicModelId);
+            ModelTypeListResponseDto response = modelOptionQueryRepository.findByModelTypeOptionsByBasicModelId(trimId);
 
             //then
             assertThat(response).isNotNull();


### PR DESCRIPTION
## 한일
- [x] 모델 타입 목록을 basicModelId 대신 trimId를 통해 조회하도록 변경
- [x] Swagger에 ModelController 설명 추가

close #270 