### PR TITLE
[Front-End] 라우터 캐러쉘 적용

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,73 @@
+.nowUnload {
+  display: none;
+}
+
+.leftNextLoad {
+  animation: 1s ease leftNextLoad forwards;
+  position: absolute;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+@keyframes leftNextLoad {
+  0% {
+    left: 100%;
+  }
+  100% {
+    left: 0;
+  }
+}
+
+.leftNowLoad {
+  animation: 1s ease leftNowLoad forwards;
+  position: absolute;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+@keyframes leftNowLoad {
+  0% {
+    left: 0%;
+  }
+
+  100% {
+    left: -100%;
+  }
+}
+
+.rightNextLoad {
+  animation: 1s ease rightNextLoad forwards;
+  position: absolute;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+@keyframes rightNextLoad {
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 0;
+  }
+}
+
+.rightNowLoad {
+  animation: 1s ease rightNowLoad forwards;
+  position: absolute;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+@keyframes rightNowLoad {
+  0% {
+    left: 0;
+  }
+
+  100% {
+    left: 100%;
+  }
+}
+
+::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,24 +1,39 @@
-import { Route, Routes } from 'react-router-dom';
+import { useRef, useState, useEffect, cloneElement } from 'react';
+import { Route, Routes, useNavigate, useLocation } from 'react-router-dom';
+import { useData } from './utils/Context';
+import './App.css';
 import InteriorColor from './pages/InteriorColorPage';
-import Layout from './components/PageLayout';
 import TrimSelect from './pages/TrimSelectPage';
 import ModelType from './pages/ModelTypePage';
 import ExteriorColor from './pages/ExteriorColorPage';
 import OptionPicker from './pages/OptionPickerPage';
 import Estimation from './pages/EstimationPage';
+import Header from './components/Header';
 
 function App() {
+  const { movePage, clonePage } = useData();
+  const nextContentRef = useRef(null);
+  const nowContentRef = useRef(null);
+
   return (
-    <Routes>
-      <Route element={<Layout />}>
-        <Route path="/" element={<TrimSelect />} />
-        <Route path="/modelType" element={<ModelType />} />
-        <Route path="/exteriorColor" element={<ExteriorColor />} />
-        <Route path="/interiorColor" element={<InteriorColor />} />
-        <Route path="/optionPicker" element={<OptionPicker />} />
-        <Route path="/estimation" element={<Estimation />} />
-      </Route>
-    </Routes>
+    <div>
+      <Header />
+      <div ref={nextContentRef} className={movePage.nextContentRef}>
+        <Routes>
+          <Route>
+            <Route path="/" element={<TrimSelect />} />
+            <Route path="/modelType" element={<ModelType />} />
+            <Route path="/exteriorColor" element={<ExteriorColor />} />
+            <Route path="/interiorColor" element={<InteriorColor />} />
+            <Route path="/optionPicker" element={<OptionPicker />} />
+            <Route path="/estimation" element={<Estimation />} />
+          </Route>
+        </Routes>
+      </div>
+      <div ref={nowContentRef} className={movePage.nowContentRef}>
+        {clonePage[movePage.clonePage]}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/Header/Nav/index.jsx
+++ b/frontend/src/components/Header/Nav/index.jsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router-dom';
-import { useData } from '../../../utils/Context';
+import { useNavigate } from 'react-router-dom';
+import { useData, StartAnimation } from '../../../utils/Context';
 import { NAV } from '../constants';
 import * as S from './style';
 import NavToggle from '../../NavToggle';
@@ -20,16 +20,35 @@ function isLinkEnabled(item, modelType, exteriorColor, interiorColor, optionPick
 }
 
 function Nav() {
-  const { page, modelType, exteriorColor, interiorColor, optionPicker } = useData();
+  const navigate = useNavigate();
+  const {
+    setTrimState,
+    page,
+    modelType,
+    exteriorColor,
+    interiorColor,
+    optionPicker,
+    pageNum,
+    pagePath,
+  } = useData();
 
   return (
     <S.Nav>
       <S.Stage>
         {NAV.map((item) => (
           <S.Step key={item.label}>
-            <S.Text className={item.page === page ? 'selected' : null}>
+            <S.Text>
               {isLinkEnabled(item, modelType, exteriorColor, interiorColor, optionPicker) ? (
-                <Link to={item.to}>{item.label}</Link>
+                <S.Button
+                  onClick={() => {
+                    const nowPath = pageNum[page];
+                    const nextPath = item.to;
+                    StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePath);
+                  }}
+                  className={item.page === page ? 'selected' : null}
+                >
+                  {item.label}
+                </S.Button>
               ) : (
                 <span>{item.label}</span>
               )}

--- a/frontend/src/components/Header/Nav/style.jsx
+++ b/frontend/src/components/Header/Nav/style.jsx
@@ -25,12 +25,17 @@ export const Text = styled.li`
   height: 22px;
   color: ${({ theme }) => theme.color.gray['200']};
   font: ${({ theme }) => theme.font.headKR.Medium14};
-
-  &.selected {
-    color: ${({ theme }) => theme.color.primary.default};
-  }
 `;
 
 export const Bar = styled.div`
   margin: 6px 17px -8px 17px;
+`;
+
+export const Button = styled.button`
+  color: ${({ theme }) => theme.color.gray['200']};
+  font: ${({ theme }) => theme.font.headKR.Medium14};
+
+  &.selected {
+    color: ${({ theme }) => theme.color.primary.default};
+  }
 `;

--- a/frontend/src/components/NextButton/index.jsx
+++ b/frontend/src/components/NextButton/index.jsx
@@ -1,20 +1,22 @@
 import { useNavigate } from 'react-router-dom';
-import { useData, TotalPrice } from '../../utils/Context';
+import { useData, TotalPrice, StartAnimation } from '../../utils/Context';
 import { TOTAL, BUTTON, ROUND_BUTTON, PAGE } from './constants';
 import * as S from './style';
 import RoundButton from '../RoundButton';
 import Button from '../Button';
 
 function NextButton() {
-  const { page, price } = useData();
   const navigate = useNavigate();
+  const { setTrimState, page, price, pagePath } = useData();
 
   const buttonProps = {
     type: BUTTON.TYPE,
     state: BUTTON.STATE,
     mainTitle: BUTTON.MAIN_TITLE,
     event: () => {
-      navigate(PAGE.find((type) => type.page === page + 1).to);
+      const nowPath = PAGE.find((type) => type.page === page).to;
+      const nextPath = PAGE.find((type) => type.page === page + 1).to;
+      StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePath);
     },
   };
 

--- a/frontend/src/components/Section/index.jsx
+++ b/frontend/src/components/Section/index.jsx
@@ -1,7 +1,7 @@
 import { useData, TotalPrice } from '../../utils/Context';
-import PriceStaticBar from '../PriceStaticBar';
 import * as S from './style';
-
+import PriceStaticBar from '../PriceStaticBar';
+import Footer from '../Footer';
 /**
  * Section 구역을 분리하는 컴포넌트
  * @param type {string} TrimSelect || ModelType || ExteriorColor || InteriorColor || AddOption
@@ -27,6 +27,7 @@ function Section({ type, url, Info, Pick, showPriceStatic = true }) {
           price={TotalPrice(price)}
         />
       )}
+      <Footer />
     </S.Section>
   );
 }

--- a/frontend/src/pages/ExteriorColorPage/index.jsx
+++ b/frontend/src/pages/ExteriorColorPage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, cloneElement } from 'react';
 import { useData } from '../../utils/Context';
 import { EXTERIOR_COLOR } from './constants';
 import Section from '../../components/Section';
@@ -33,9 +33,24 @@ function ExteriorColor() {
               return `${defaultData.carImageDirectory}${imageNumber}.png`;
             }),
           },
+          clonePage: {
+            ...prevState.clonePage,
+            3: cloneElement(<ExteriorColor />),
+          },
         }));
       }
       setTrimState((prevState) => ({ ...prevState, page: 3 }));
+      setTimeout(() => {
+        setTrimState((prevState) => ({
+          ...prevState,
+          movePage: {
+            ...prevState.movePage,
+            clonePage: 3,
+            nowContentRef: 'nowUnload',
+            nextContentRef: 'nextUnload',
+          },
+        }));
+      }, 1000);
     }
     fetchData();
   }, []);

--- a/frontend/src/pages/InteriorColorPage/index.jsx
+++ b/frontend/src/pages/InteriorColorPage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, cloneElement } from 'react';
 import { useData } from '../../utils/Context';
 import { INTERIOR_COLOR } from './constants';
 import Section from '../../components/Section';
@@ -29,9 +29,24 @@ function InteriorColor() {
             name: defaultData.name,
             carImageUrl: defaultData.carImageUrl,
           },
+          clonePage: {
+            ...prevState.clonePage,
+            4: cloneElement(<InteriorColor />),
+          },
         }));
       }
       setTrimState((prevState) => ({ ...prevState, page: 4 }));
+      setTimeout(() => {
+        setTrimState((prevState) => ({
+          ...prevState,
+          movePage: {
+            ...prevState.movePage,
+            clonePage: 4,
+            nowContentRef: 'nowUnload',
+            nextContentRef: 'nextUnload',
+          },
+        }));
+      }, 1000);
     }
     fetchData();
   }, []);

--- a/frontend/src/pages/ModelTypePage/index.jsx
+++ b/frontend/src/pages/ModelTypePage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, cloneElement } from 'react';
 import { useData } from '../../utils/Context';
 import { MODEL_TYPE } from './constants';
 import Section from '../../components/Section';
@@ -27,7 +27,6 @@ function ModelType() {
           bodyTypeOption: findOptionByTypeAndId(modelType.bodyTypeType, modelType.bodyTypeId),
           wheelDriveOption: findOptionByTypeAndId(modelType.wheelDriveType, modelType.wheelDriveId),
         };
-
         setTrimState((prevState) => ({
           ...prevState,
           trim: {
@@ -35,9 +34,24 @@ function ModelType() {
             isDefault: true,
           },
           modelType: updatedModelType,
+          clonePage: {
+            ...prevState.clonePage,
+            2: cloneElement(<ModelType />),
+          },
         }));
       }
       setTrimState((prevState) => ({ ...prevState, page: 2 }));
+      setTimeout(() => {
+        setTrimState((prevState) => ({
+          ...prevState,
+          movePage: {
+            ...prevState.movePage,
+            clonePage: 2,
+            nowContentRef: 'nowUnload',
+            nextContentRef: 'nextUnload',
+          },
+        }));
+      }, 1000);
     }
     fetchData();
   }, []);

--- a/frontend/src/pages/OptionPickerPage/index.jsx
+++ b/frontend/src/pages/OptionPickerPage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, cloneElement } from 'react';
 import Section from '../../components/Section';
 import Info from './Info';
 import Pick from './Pick';
@@ -67,7 +67,23 @@ function OptionPicker() {
     setTrimState((prevState) => ({
       ...prevState,
       page: 5,
+      clonePage: {
+        ...prevState.clonePage,
+        5: cloneElement(<OptionPicker />),
+      },
     }));
+    setTimeout(() => {
+      setTrimState((prevState) => ({
+        ...prevState,
+        page: 5,
+        movePage: {
+          ...prevState.movePage,
+          clonePage: 5,
+          nowContentRef: 'nowUnload',
+          nextContentRef: 'nextUnload',
+        },
+      }));
+    }, 1000);
   }, [setTrimState]);
 
   const InfoProps = { imageUrl: IMAGE_URL };

--- a/frontend/src/pages/TrimSelectPage/Pick/TrimCard/index.jsx
+++ b/frontend/src/pages/TrimSelectPage/Pick/TrimCard/index.jsx
@@ -1,18 +1,17 @@
 import { useNavigate } from 'react-router-dom';
-import { useData } from '../../../../utils/Context';
+import { useData, StartAnimation } from '../../../../utils/Context';
 import { PAGE, TRIM_CARD } from '../../constants';
 import * as S from './style';
 import Button from '../../../../components/Button';
 
 function TrimCard({ name, description, price, defaultInfo, active, onClick }) {
-  const { setTrimState, trim, page } = useData();
   const navigate = useNavigate();
+  const { setTrimState, trim, page, pagePath } = useData();
 
   const goToNextPage = () => {
-    const nextPage = PAGE.find((type) => type.page === page + 1);
-    if (nextPage) {
-      navigate(nextPage.to);
-    }
+    const nowPath = PAGE.find((type) => type.page === page).to;
+    const nextPath = PAGE.find((type) => type.page === page + 1).to;
+    StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePath);
   };
 
   const updateState = () => {

--- a/frontend/src/pages/TrimSelectPage/index.jsx
+++ b/frontend/src/pages/TrimSelectPage/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, cloneElement } from 'react';
 import { useData } from '../../utils/Context';
 import { TRIM_SELECT } from './constants';
 import Section from '../../components/Section';
@@ -21,9 +21,24 @@ function TrimSelect() {
             fetchData: [...dataFetch.trims],
             isFetch: true,
           },
+          clonePage: {
+            ...prevState.clonePage,
+            1: cloneElement(<TrimSelect />),
+          },
         }));
       }
       setTrimState((prevState) => ({ ...prevState, page: 1 }));
+      setTimeout(() => {
+        setTrimState((prevState) => ({
+          ...prevState,
+          movePage: {
+            ...prevState.movePage,
+            clonePage: 1,
+            nowContentRef: 'nowUnload',
+            nextContentRef: 'nextUnload',
+          },
+        }));
+      }, 1000);
     }
     fetchData();
   }, []);

--- a/frontend/src/utils/Context/index.jsx
+++ b/frontend/src/utils/Context/index.jsx
@@ -11,6 +11,10 @@ export function StateProvider({ children }) {
     'interiorColor',
     'optionPicker',
     'price',
+    'pagePath',
+    'pageNum',
+    'clonePage',
+    'movePage',
   ];
 
   const initialState = stateKeys.reduce((acc, key) => {
@@ -87,6 +91,46 @@ export function StateProvider({ children }) {
             'https://want-car-image.s3.ap-northeast-2.amazonaws.com/palisade/le-blanc/options/10_driverseat_s.jpg',
         };
         break;
+      case 'pagePath':
+        acc[key] = {
+          '/': 1,
+          '/modelType': 2,
+          '/exteriorColor': 3,
+          '/interiorColor': 4,
+          '/optionPicker': 5,
+          '/estimation': 6,
+        };
+        break;
+      case 'pageNum':
+        acc[key] = {
+          1: '/',
+          2: '/modelType',
+          3: '/exteriorColor',
+          4: '/interiorColor',
+          5: '/optionPicker',
+          6: '/estimation',
+        };
+        break;
+      case 'clonePage':
+        acc[key] = {
+          1: null,
+          2: null,
+          3: null,
+          4: null,
+          5: null,
+          6: null,
+        };
+        break;
+      case 'movePage':
+        acc[key] = {
+          path: [],
+          pathLength: null,
+          clonePage: null,
+          startAnimation: null,
+          nowContentRef: null,
+          nextContentRef: null,
+        };
+        break;
       default:
         acc[key] = null; // 다른 키들은 null로 초기화
     }
@@ -117,4 +161,31 @@ export function TotalPrice(priceObj) {
   const prices = Object.values(priceObj);
   const totalPrice = prices.reduce((acc, price) => acc + (price || 0), 0);
   return totalPrice;
+}
+
+export function StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePath) {
+  navigate(nextPath);
+
+  if (pagePath[nextPath] > pagePath[nowPath]) {
+    console.log('왼쪽');
+    setTrimState((prevState) => ({
+      ...prevState,
+      movePage: {
+        ...prevState.movePage,
+        nowContentRef: 'leftNowLoad',
+        nextContentRef: 'leftNextLoad',
+      },
+    }));
+  }
+  if (pagePath[nextPath] < pagePath[nowPath]) {
+    console.log('오른쪽');
+    setTrimState((prevState) => ({
+      ...prevState,
+      movePage: {
+        ...prevState.movePage,
+        nowContentRef: 'rightNowLoad',
+        nextContentRef: 'rightNextLoad',
+      },
+    }));
+  }
 }

--- a/frontend/src/utils/Context/index.jsx
+++ b/frontend/src/utils/Context/index.jsx
@@ -129,6 +129,7 @@ export function StateProvider({ children }) {
           startAnimation: null,
           nowContentRef: null,
           nextContentRef: null,
+          timeoutId: null,
         };
         break;
       default:
@@ -167,7 +168,6 @@ export function StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePa
   navigate(nextPath);
 
   if (pagePath[nextPath] > pagePath[nowPath]) {
-    console.log('왼쪽');
     setTrimState((prevState) => ({
       ...prevState,
       movePage: {
@@ -178,7 +178,6 @@ export function StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePa
     }));
   }
   if (pagePath[nextPath] < pagePath[nowPath]) {
-    console.log('오른쪽');
     setTrimState((prevState) => ({
       ...prevState,
       movePage: {
@@ -188,4 +187,15 @@ export function StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePa
       },
     }));
   }
+}
+
+export function customSetTimeout(callback, delay, setTrimState, movePage) {
+  clearTimeout(movePage.timeoutId);
+  setTrimState((prevState) => ({
+    ...prevState,
+    movePage: {
+      ...prevState.movePage,
+      timeoutId: setTimeout(callback, delay),
+    },
+  }));
 }


### PR DESCRIPTION
## Fix
- [ ] setInterval 중복 수정
- [ ] 뒤로가기 감지
- [ ] 완료페이지 적용

## Router Carousel
현재 링크와 다음 링크의 순서를 비교해서 애니메이션을 적용

```js
export function StartAnimation(nowPath, nextPath, navigate, setTrimState, pagePath) {
  navigate(nextPath);

  if (pagePath[nextPath] > pagePath[nowPath]) {
    setTrimState((prevState) => ({
      ...prevState,
      movePage: {
        ...prevState.movePage,
        nowContentRef: 'leftNowLoad',
        nextContentRef: 'leftNextLoad',
      },
    }));
  }
  if (pagePath[nextPath] < pagePath[nowPath]) {
    setTrimState((prevState) => ({
      ...prevState,
      movePage: {
        ...prevState.movePage,
        nowContentRef: 'rightNowLoad',
        nextContentRef: 'rightNextLoad',
      },
    }));
  }
}
```

## Issues
- close #232 