### PR TITLE
[Front-End] fix: 브라우저 width 줄어들었을 때 레이아웃 깨지는 문제 수정

### DIFF
--- a/frontend/src/components/Interaction/index.jsx
+++ b/frontend/src/components/Interaction/index.jsx
@@ -15,7 +15,7 @@ function Interaction() {
 
   useEffect(() => {
     pageRef.current.style.transition = 'all 1.5s ease-in-out';
-    pageRef.current.style.transform = `translateX(-${page - 1}00%)`;
+    pageRef.current.style.transform = `translateX(min(-${page - 1}00%, -${(page - 1) * 1280}px))`;
   }, [page]);
 
   return (


### PR DESCRIPTION
# Changes

* 브라우저 width가 1200px보다 작을 때 이전 페이지 요소가 보이는 문제 수정

# Related Issues

* Close #309 