### PR TITLE
[Backend] 유사 출고 견적 조회 API 구현 #119

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/controller/SimilarityController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/controller/SimilarityController.java
@@ -1,0 +1,35 @@
+package softeer.wantcar.cartalog.estimate.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
+import softeer.wantcar.cartalog.estimate.service.SimilarityService;
+
+@Api(tags = {"유사 견적 관련 API"})
+@RestController
+@RequiredArgsConstructor
+public class SimilarityController {
+    private final SimilarityService similarityService;
+
+    @ApiOperation(
+            value = "유사 견적 조회",
+            notes = "견적 식별자와 유사한 견적 정보를 제공한다.")
+    @ApiImplicitParam(
+            name = "estimateId", value = "견적 식별자", required = true,
+            dataType = "java.lang.Long", paramType = "query", example = "1")
+    @ApiResponses({
+            @ApiResponse(code = 404, message = "존재하지 않는 견적 식별자입니다."),
+            @ApiResponse(code = 500, message = "적절하지 않은 데이터가 있어 요청을 처리할 수 없습니다. 관리자에게 문의하세요.")})
+    @GetMapping("/releases")
+    public ResponseEntity<SimilarEstimateResponseDto> findSimilarEstimates(@RequestParam("estimateId") Long estimateId) {
+        SimilarEstimateResponseDto similarEstimateDtoList = similarityService.getSimilarEstimateDtoList(estimateId);
+        if(similarEstimateDtoList == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok().body(similarEstimateDtoList);
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/controller/SimilarityController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/controller/SimilarityController.java
@@ -27,7 +27,7 @@ public class SimilarityController {
     @GetMapping("/releases")
     public ResponseEntity<SimilarEstimateResponseDto> findSimilarEstimates(@RequestParam("estimateId") Long estimateId) {
         SimilarEstimateResponseDto similarEstimateDtoList = similarityService.getSimilarEstimateDtoList(estimateId);
-        if(similarEstimateDtoList == null) {
+        if (similarEstimateDtoList == null) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok().body(similarEstimateDtoList);

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/SimilarEstimateDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/SimilarEstimateDto.java
@@ -1,0 +1,19 @@
+package softeer.wantcar.cartalog.estimate.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class SimilarEstimateDto {
+    private Long detailTrimId;
+    private String trimName;
+    private int price;
+    private List<String> modelTypes;
+    private String exteriorColorCode;
+    private String interiorColorCode;
+    private List<EstimateOptionInfoDto> nonExistentOptions;
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/SimilarEstimateResponseDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/SimilarEstimateResponseDto.java
@@ -1,0 +1,14 @@
+package softeer.wantcar.cartalog.estimate.dto;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@EqualsAndHashCode
+public class SimilarEstimateResponseDto {
+    private List<SimilarEstimateDto> similarEstimates;
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
@@ -16,5 +16,6 @@ public interface EstimateQueryRepository {
     }
 
     EstimateOptionListDto findEstimateOptionIdsByEstimateId(Long estimateId);
+
     Long findAveragePrice(Long trimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
@@ -16,5 +16,5 @@ public interface EstimateQueryRepository {
     }
 
     EstimateOptionListDto findEstimateOptionIdsByEstimateId(Long estimateId);
-    long findAveragePrice(Long trimId);
+    Long findAveragePrice(Long trimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepository.java
@@ -1,5 +1,20 @@
 package softeer.wantcar.cartalog.estimate.repository;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+
 public interface EstimateQueryRepository {
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    class EstimateOptionIdsResult {
+        private Long trimId;
+        private Long optionId;
+        private Long packageId;
+    }
+
+    EstimateOptionListDto findEstimateOptionIdsByEstimateId(Long estimateId);
     long findAveragePrice(Long trimId);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryImpl.java
@@ -6,7 +6,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+import softeer.wantcar.cartalog.global.utils.RowMapperUtils;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"SqlNoDataSourceInspection", "SqlResolve"})
 @Repository
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -14,6 +20,29 @@ public class EstimateQueryRepositoryImpl implements EstimateQueryRepository {
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     @Override
+    public EstimateOptionListDto findEstimateOptionIdsByEstimateId(Long estimateId) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("estimateId", estimateId);
+        List<EstimateOptionIdsResult> queryResult = jdbcTemplate.query(QueryString.findEstimateOptionIdsByEstimateId,
+                parameters, RowMapperUtils.mapping(EstimateOptionIdsResult.class));
+        if (queryResult.isEmpty()) {
+            return null;
+        }
+
+        List<Long> optionIds = queryResult.stream()
+                .map(EstimateOptionIdsResult::getOptionId)
+                .filter(id -> id > 0)
+                .distinct()
+                .collect(Collectors.toList());
+        List<Long> packageIds = queryResult.stream()
+                .map(EstimateOptionIdsResult::getPackageId)
+                .filter(id -> id > 0)
+                .distinct()
+                .collect(Collectors.toList());
+
+        return new EstimateOptionListDto(queryResult.get(0).getTrimId(), optionIds, packageIds);
+    }
+
     public long findAveragePrice(Long trimId) {
         SqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("trimId", trimId);

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryImpl.java
@@ -43,48 +43,10 @@ public class EstimateQueryRepositoryImpl implements EstimateQueryRepository {
         return new EstimateOptionListDto(queryResult.get(0).getTrimId(), optionIds, packageIds);
     }
 
-    public long findAveragePrice(Long trimId) {
+    @Override
+    public Long findAveragePrice(Long trimId) {
         SqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("trimId", trimId);
-
-        String findAveragePriceQuery = "SELECT ROUND(COALESCE(AVG(price), 0)) AS average_price " +
-                "FROM ( " +
-                "    SELECT COALESCE(estimates_price.price, 0) + COALESCE(package_price.price, 0) + COALESCE(option_price.price, 0) AS price " +
-                "    FROM release_records " +
-                "    INNER JOIN estimates " +
-                "    ON estimates.id = release_records.estimate_id " +
-                "    LEFT JOIN ( " +
-                "        SELECT estimates.id, trims.min_price + model_exterior_colors.price + model_interior_colors.price AS price " +
-                "        FROM estimates " +
-                "        INNER JOIN detail_trims ON detail_trims.id = estimates.detail_trim_id " +
-                "        INNER JOIN trims ON trims.id = detail_trims.trim_id " +
-                "        INNER JOIN trim_exterior_colors ON trim_exterior_colors.id = estimates.trim_exterior_color_id " +
-                "        INNER JOIN model_exterior_colors ON model_exterior_colors.id = trim_exterior_colors.model_exterior_color_id " +
-                "        INNER JOIN trim_interior_colors ON trim_interior_colors.id = estimates.trim_interior_color_id " +
-                "        INNER JOIN model_interior_colors ON model_interior_colors.code = trim_interior_colors.model_interior_color_code " +
-                "    ) AS estimates_price ON estimates.id = estimates_price.id " +
-                "    LEFT JOIN ( " +
-                "        SELECT estimates.id, SUM(model_packages.price) AS price " +
-                "        FROM estimates " +
-                "        LEFT JOIN estimate_packages ON estimate_packages.estimate_id = estimates.id " +
-                "        INNER JOIN model_packages ON model_packages.id = estimate_packages.model_package_id " +
-                "        GROUP BY estimates.id " +
-                "    ) AS package_price ON estimates.id = package_price.id " +
-                "    LEFT JOIN ( " +
-                "        SELECT estimates.id, SUM(model_options.price) AS price " +
-                "        FROM estimates " +
-                "        LEFT JOIN estimate_options ON estimate_options.estimate_id = estimates.id " +
-                "        INNER JOIN model_options ON model_options.id = estimate_options.model_option_id " +
-                "        GROUP BY estimates.id " +
-                "    ) AS option_price ON estimates.id = option_price.id " +
-                "    WHERE EXISTS ( " +
-                "        SELECT 1 " +
-                "        FROM detail_trims " +
-                "        INNER JOIN trims ON trims.id = detail_trims.trim_id " +
-                "        WHERE trims.id = :trimId AND detail_trims.id = estimates.detail_trim_id " +
-                "    ) " +
-                ") AS combined_price ";
-
-        return jdbcTemplate.queryForObject(findAveragePriceQuery, parameters, long.class);
+        return jdbcTemplate.queryForObject(QueryString.findAveragePrice, parameters, Long.class);
     }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
@@ -80,4 +80,43 @@ public class QueryString {
             "JOIN estimate_packages AS ep ON ep.estimate_id=e.id " +
             "JOIN model_packages AS mp ON mp.id=ep.model_package_id " +
             "WHERE e.id IN (:similarEstimateIds)";
+
+    protected static final String findAveragePrice =
+            "SELECT ROUND(COALESCE(AVG(price), 0)) AS average_price " +
+            "FROM ( " +
+            "    SELECT COALESCE(estimates_price.price, 0) + COALESCE(package_price.price, 0) + COALESCE(option_price.price, 0) AS price " +
+            "    FROM release_records " +
+            "    INNER JOIN estimates " +
+            "    ON estimates.id = release_records.estimate_id " +
+            "    LEFT JOIN ( " +
+            "        SELECT estimates.id, trims.min_price + model_exterior_colors.price + model_interior_colors.price AS price " +
+            "        FROM estimates " +
+            "        INNER JOIN detail_trims ON detail_trims.id = estimates.detail_trim_id " +
+            "        INNER JOIN trims ON trims.id = detail_trims.trim_id " +
+            "        INNER JOIN trim_exterior_colors ON trim_exterior_colors.id = estimates.trim_exterior_color_id " +
+            "        INNER JOIN model_exterior_colors ON model_exterior_colors.id = trim_exterior_colors.model_exterior_color_id " +
+            "        INNER JOIN trim_interior_colors ON trim_interior_colors.id = estimates.trim_interior_color_id " +
+            "        INNER JOIN model_interior_colors ON model_interior_colors.code = trim_interior_colors.model_interior_color_code " +
+            "    ) AS estimates_price ON estimates.id = estimates_price.id " +
+            "    LEFT JOIN ( " +
+            "        SELECT estimates.id, SUM(model_packages.price) AS price " +
+            "        FROM estimates " +
+            "        LEFT JOIN estimate_packages ON estimate_packages.estimate_id = estimates.id " +
+            "        INNER JOIN model_packages ON model_packages.id = estimate_packages.model_package_id " +
+            "        GROUP BY estimates.id " +
+            "    ) AS package_price ON estimates.id = package_price.id " +
+            "    LEFT JOIN ( " +
+            "        SELECT estimates.id, SUM(model_options.price) AS price " +
+            "        FROM estimates " +
+            "        LEFT JOIN estimate_options ON estimate_options.estimate_id = estimates.id " +
+            "        INNER JOIN model_options ON model_options.id = estimate_options.model_option_id " +
+            "        GROUP BY estimates.id " +
+            "    ) AS option_price ON estimates.id = option_price.id " +
+            "    WHERE EXISTS ( " +
+            "        SELECT 1 " +
+            "        FROM detail_trims " +
+            "        INNER JOIN trims ON trims.id = detail_trims.trim_id " +
+            "        WHERE trims.id = :trimId AND detail_trims.id = estimates.detail_trim_id " +
+            "    ) " +
+            ") AS combined_price ";
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
@@ -1,0 +1,83 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+public class QueryString {
+    private QueryString() {
+    }
+
+    protected static final String findEstimateOptionIdsByEstimateId =
+            "SELECT DISTINCT " +
+            "   dt.trim_id AS trim_id, " +
+            "   eo.model_option_id AS option_id, " +
+            "   ep.model_package_id AS package_id " +
+            "FROM estimates AS e " +
+            "JOIN detail_trims AS dt ON dt.id=e.detail_trim_id " +
+            "LEFT OUTER JOIN estimate_options AS eo ON eo.estimate_id = e.id " +
+            "LEFT OUTER JOIN estimate_packages AS ep ON ep.estimate_id = e.id " +
+            "WHERE e.id= :estimateId";
+
+    protected static final String findPendingHashTagKey =
+            "SELECT pending_hash_tag_left_key " +
+            "FROM pending_hash_tag_similarities " +
+            "WHERE hash_tag_key= :hashTagKey " +
+            "   AND trim_id= :trimId ";
+
+    protected static final String findCalculatedSimilarHashTagKeys =
+            "SELECT " +
+            "   hash_tag_left_key AS hash_tag_key, " +
+            "FROM hash_tag_similarities " +
+            "WHERE hash_tag_key= :hashTagKey " +
+            "   AND trim_id= :trimId " +
+            "   AND similarity BETWEEN 0.2 AND 0.9 " +
+            "ORDER BY similarity DESC ";
+
+    protected static final String findSimilarEstimateIds =
+            "SELECT estimate_id " +
+            "FROM similar_estimates " +
+            "WHERE hash_tag_key IN (:hashTagKey) " +
+            "   AND trim_id= :trimId " +
+            "LIMIT 4";
+
+    protected static final String findSimilarEstimateInfoByEstimateIds =
+            "SELECT " +
+            "   e.id AS estimate_id, " +
+            "   e.detail_trim_id AS detail_trim_id, " +
+            "   t.name AS trim_name, " +
+            "   t.min_price AS trim_price, " +
+            "   mec.color_code AS exterior_color_code, " +
+            "   tic.model_interior_color_code AS interior_color_code, " +
+            "   mo.name AS model_type_name, " +
+            "   mo.price AS model_type_price " +
+            "FROM estimates AS e " +
+            "JOIN detail_trims AS dt ON dt.id=e.detail_trim_id " +
+            "JOIN trims AS t ON t.id=dt.trim_id " +
+            "JOIN detail_model_decision_options AS dmdo ON dmdo.detail_model_id = dt.detail_model_id " +
+            "JOIN model_options AS mo ON mo.id=dmdo.model_option_id " +
+            "JOIN trim_exterior_colors AS tec ON tec.id=e.trim_exterior_color_id " +
+            "JOIN model_exterior_colors AS mec ON mec.id=tec.model_exterior_color_id " +
+            "JOIN trim_interior_colors AS tic ON tic.id=e.trim_interior_color_id " +
+            "WHERE e.id IN (:similarEstimateIds);";
+
+    protected static final String findSimilarEstimateOptionsByEstimateIds =
+            "SELECT " +
+            "   e.id AS estimate_id, " +
+            "   mo.id AS option_id, " +
+            "   mo.name AS name, " +
+            "   mo.price AS price, " +
+            "   mo.image_url AS image_url " +
+            "FROM estimates AS e " +
+            "JOIN estimate_options AS eo ON eo.estimate_id=e.id " +
+            "JOIN model_options AS mo ON mo.id=eo.model_option_id " +
+            "WHERE e.id IN (:similarEstimateIds)";
+
+    protected static final String findSimilarEstimatePackagesByEstimateIds =
+            "SELECT " +
+            "   e.id AS estimate_id, " +
+            "   mp.id AS option_id, " +
+            "   mp.name AS name, " +
+            "   mp.price AS price, " +
+            "   mp.image_url AS image_url " +
+            "FROM estimates AS e " +
+            "JOIN estimate_packages AS ep ON ep.estimate_id=e.id " +
+            "JOIN model_packages AS mp ON mp.id=ep.model_package_id " +
+            "WHERE e.id IN (:similarEstimateIds)";
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepository.java
@@ -1,0 +1,12 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SimilarityCommandRepository {
+    void savePendingToOther(Long trimId, String hashTagKey, List<String> otherHashTagKeys);
+
+    void deletePending(Long trimId, String hashTagKey);
+
+    void saveCalculatedHashTagKeys(Long trimId, String hashTagKey, Map<String, Double> similarities);
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryImpl.java
@@ -21,7 +21,7 @@ public class SimilarityCommandRepositoryImpl implements SimilarityCommandReposit
     @Override
     public void savePendingToOther(Long trimId, String hashTagKey, List<String> otherHashTagKeys) {
         StringBuilder insertSQL = new StringBuilder("INSERT INTO pending_hash_tag_similarities " +
-                                                    "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES ");
+                "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES ");
         List<String> batchInsertValues = otherHashTagKeys.stream()
                 .map(otherHashTagKey -> "('" + otherHashTagKey + "', '" + hashTagKey + "', " + trimId + ") ")
                 .collect(Collectors.toList());
@@ -36,16 +36,16 @@ public class SimilarityCommandRepositoryImpl implements SimilarityCommandReposit
                 .addValue("hashTagKey", hashTagKey);
 
         jdbcTemplate.update("DELETE FROM pending_hash_tag_similarities " +
-                            "WHERE trim_id= :trimId AND hash_tag_key= :hashTagKey ", parameters);
+                "WHERE trim_id= :trimId AND hash_tag_key= :hashTagKey ", parameters);
     }
 
     @Override
     public void saveCalculatedHashTagKeys(Long trimId, String hashTagKey, Map<String, Double> similarities) {
         StringBuilder insertSQL = new StringBuilder("INSERT INTO hash_tag_similarities " +
-                                                    "(hash_tag_left_key, hash_tag_key, trim_id, similarity) VALUES ");
+                "(hash_tag_left_key, hash_tag_key, trim_id, similarity) VALUES ");
         List<String> batchInsertValues = similarities.keySet().stream()
                 .map(otherHashTagKey -> "('" + otherHashTagKey + "', '" + hashTagKey + "', " +
-                                        trimId + ", " + similarities.get(otherHashTagKey) + ") ")
+                        trimId + ", " + similarities.get(otherHashTagKey) + ") ")
                 .collect(Collectors.toList());
         String batchInsertSQL = getBatchInsertSQL(insertSQL, batchInsertValues);
         jdbcTemplate.update(batchInsertSQL, new MapSqlParameterSource());

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryImpl.java
@@ -1,0 +1,63 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class SimilarityCommandRepositoryImpl implements SimilarityCommandRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public void savePendingToOther(Long trimId, String hashTagKey, List<String> otherHashTagKeys) {
+        StringBuilder insertSQL = new StringBuilder("INSERT INTO pending_hash_tag_similarities " +
+                                                    "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES ");
+        List<String> batchInsertValues = otherHashTagKeys.stream()
+                .map(otherHashTagKey -> "('" + otherHashTagKey + "', '" + hashTagKey + "', " + trimId + ") ")
+                .collect(Collectors.toList());
+        String batchInsertSQL = getBatchInsertSQL(insertSQL, batchInsertValues);
+        jdbcTemplate.update(batchInsertSQL, new MapSqlParameterSource());
+    }
+
+    @Override
+    public void deletePending(Long trimId, String hashTagKey) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("trimId", trimId)
+                .addValue("hashTagKey", hashTagKey);
+
+        jdbcTemplate.update("DELETE FROM pending_hash_tag_similarities " +
+                            "WHERE trim_id= :trimId AND hash_tag_key= :hashTagKey ", parameters);
+    }
+
+    @Override
+    public void saveCalculatedHashTagKeys(Long trimId, String hashTagKey, Map<String, Double> similarities) {
+        StringBuilder insertSQL = new StringBuilder("INSERT INTO hash_tag_similarities " +
+                                                    "(hash_tag_left_key, hash_tag_key, trim_id, similarity) VALUES ");
+        List<String> batchInsertValues = similarities.keySet().stream()
+                .map(otherHashTagKey -> "('" + otherHashTagKey + "', '" + hashTagKey + "', " +
+                                        trimId + ", " + similarities.get(otherHashTagKey) + ") ")
+                .collect(Collectors.toList());
+        String batchInsertSQL = getBatchInsertSQL(insertSQL, batchInsertValues);
+        jdbcTemplate.update(batchInsertSQL, new MapSqlParameterSource());
+    }
+
+    private String getBatchInsertSQL(StringBuilder sql, List<String> batchInsertValues) {
+        for (int idx = 0; idx < batchInsertValues.size(); idx++) {
+            sql.append(batchInsertValues.get(idx));
+            if (idx != batchInsertValues.size() - 1) {
+                sql.append(", ");
+            }
+        }
+        return sql.toString();
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepository.java
@@ -1,0 +1,33 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+
+import java.util.List;
+
+public interface SimilarityQueryRepository {
+    @Getter
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    class SimilarityInfo {
+        private HashTagMap hashTagMap;
+        private Float similarity;
+    }
+
+    List<HashTagMap> findPendingHashTagMapByTrimIdAndHashTagKey(Long trimId, String hashTagKey);
+
+    List<String> findSimilarHashTagKeysByTrimIdAndHashTagKey(Long trimId, String hashTagKey);
+
+    List<Long> findSimilarEstimateIdsByTrimIdAndHashTagKey(Long trimId, List<String> hashTagKey);
+
+    List<EstimateInfoDto> findSimilarEstimateInfoBydEstimateIds(List<Long> similarEstimateIds);
+
+    List<EstimateOptionInfoDto> findSimilarEstimateOptionsByEstimateIds(List<Long> similarEstimateIds);
+
+    List<EstimateOptionInfoDto> findSimilarEstimatePackagesBtEstimateIds(List<Long> similarEstimateIds);
+
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepository.java
@@ -3,9 +3,9 @@ package softeer.wantcar.cartalog.estimate.repository;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 
 import java.util.List;
 

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryImpl.java
@@ -6,9 +6,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.global.utils.RowMapperUtils;
 
 import java.sql.ResultSet;

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryImpl.java
@@ -1,0 +1,94 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.global.utils.RowMapperUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SimilarityQueryRepositoryImpl implements SimilarityQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<HashTagMap> findPendingHashTagMapByTrimIdAndHashTagKey(Long trimId, String hashTagKey) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("trimId", trimId)
+                .addValue("hashTagKey", hashTagKey);
+        List<String> pendingHashTags = jdbcTemplate.queryForList(QueryString.findPendingHashTagKey, parameters, String.class);
+        return getHashTagMaps(pendingHashTags);
+    }
+
+    @Override
+    public List<String> findSimilarHashTagKeysByTrimIdAndHashTagKey(Long trimId, String hashTagKey) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("trimId", trimId)
+                .addValue("hashTagKey", hashTagKey);
+
+        return jdbcTemplate.queryForList(QueryString.findCalculatedSimilarHashTagKeys,
+                parameters, String.class);
+    }
+
+    @Override
+    public List<Long> findSimilarEstimateIdsByTrimIdAndHashTagKey(Long trimId, List<String> hashTagKey) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("trimId", trimId)
+                .addValue("hashTagKey", hashTagKey);
+
+        return jdbcTemplate.queryForList(QueryString.findSimilarEstimateIds, parameters, Long.TYPE);
+    }
+
+    @Override
+    public List<EstimateInfoDto> findSimilarEstimateInfoBydEstimateIds(List<Long> similarEstimateIds) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("similarEstimateIds", similarEstimateIds);
+        return jdbcTemplate.query(QueryString.findSimilarEstimateInfoByEstimateIds,
+                parameters, RowMapperUtils.mapping(EstimateInfoDto.class));
+    }
+
+    @Override
+    public List<EstimateOptionInfoDto> findSimilarEstimateOptionsByEstimateIds(List<Long> similarEstimateIds) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("similarEstimateIds", similarEstimateIds);
+        return jdbcTemplate.query(QueryString.findSimilarEstimateOptionsByEstimateIds,
+                parameters, (rs, rowNum) -> getEstimateOptionInfoDto(rs, true));
+    }
+
+    @Override
+    public List<EstimateOptionInfoDto> findSimilarEstimatePackagesBtEstimateIds(List<Long> similarEstimateIds) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("similarEstimateIds", similarEstimateIds);
+        return jdbcTemplate.query(QueryString.findSimilarEstimatePackagesByEstimateIds,
+                parameters, (rs, rowNum) -> getEstimateOptionInfoDto(rs, false));
+    }
+
+    private static List<HashTagMap> getHashTagMaps(List<String> pendingHashTags) {
+        return pendingHashTags.stream()
+                .map(HashTagMap::new)
+                .collect(Collectors.toList());
+    }
+
+    private EstimateOptionInfoDto getEstimateOptionInfoDto(ResultSet rs, boolean isOption) throws SQLException {
+        String optionPrefix = isOption ? "O" : "P";
+        return EstimateOptionInfoDto.builder()
+                .estimateId(rs.getLong("estimate_id"))
+                .optionId(optionPrefix + rs.getLong("option_id"))
+                .name(rs.getString("name"))
+                .price(rs.getInt("price"))
+                .imageUrl(rs.getString("image_url"))
+                .build();
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateInfoDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateInfoDto.java
@@ -1,0 +1,19 @@
+package softeer.wantcar.cartalog.estimate.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EstimateInfoDto {
+    private Long estimateId;
+    private Long detailTrimId;
+    private String trimName;
+    private int trimPrice;
+    private String modelTypeName;
+    private int modelTypePrice;
+    private String exteriorColorCode;
+    private String interiorColorCode;
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateOptionInfoDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateOptionInfoDto.java
@@ -1,0 +1,16 @@
+package softeer.wantcar.cartalog.estimate.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EstimateOptionInfoDto {
+    private Long estimateId;
+    private String optionId;
+    private String name;
+    private String imageUrl;
+    private int price;
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateOptionListDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateOptionListDto.java
@@ -1,0 +1,32 @@
+package softeer.wantcar.cartalog.estimate.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class EstimateOptionListDto {
+    private Long trimId;
+    private List<Long> optionIds;
+    private List<Long> packageIds;
+
+    public List<String> getAllOptionIds() {
+        List<String> totalOptionIds = new ArrayList<>();
+        totalOptionIds.addAll(getFormattedOptionId(optionIds, true));
+        totalOptionIds.addAll(getFormattedOptionId(packageIds, false));
+        return totalOptionIds;
+    }
+
+    private List<String> getFormattedOptionId(List<Long> optionIds, boolean isOption) {
+        String optionPrefix = isOption ? "O" : "P";
+        return optionIds.stream()
+                .map(id -> optionPrefix + id)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/HashTagMap.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/HashTagMap.java
@@ -1,0 +1,73 @@
+package softeer.wantcar.cartalog.estimate.repository.dto;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class HashTagMap {
+    private final SortedMap<String, Long> hashTags;
+
+    public HashTagMap(List<String> hashTags) {
+        this(new TreeMap<>(hashTags.stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))));
+    }
+
+    public HashTagMap(String hashTagKey) {
+        SortedMap<String, Long> curHashTagMap = new TreeMap<>();
+        for (String hashTag : hashTagKey.split("\\|")) {
+            String[] keyAndValue = hashTag.split(":");
+            curHashTagMap.put(keyAndValue[0], Long.parseLong(keyAndValue[1]));
+        }
+        hashTags = curHashTagMap;
+    }
+
+    public String getKey() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String key : hashTags.keySet()) {
+            stringBuilder.append(key);
+            stringBuilder.append(":");
+            stringBuilder.append(hashTags.get(key));
+            stringBuilder.append("|");
+        }
+        return stringBuilder.toString();
+    }
+
+    public double getSimilarity(HashTagMap other) {
+        SortedMap<String, Long> otherHashTags = other.getHashTags();
+        long upperValue = getUpperValue(getHashTags(), otherHashTags, getAllKeys(getHashTags(), otherHashTags));
+        double lowerValue = getHashTagVectorSize(getHashTags()) * getHashTagVectorSize(otherHashTags);
+
+        if(lowerValue == 0) {
+            return 0;
+        }
+        return 1 - (upperValue / lowerValue);
+    }
+
+    private static double getHashTagVectorSize(Map<String, Long> hashTagMap) {
+        return Math.sqrt(hashTagMap.values().stream()
+                .map(value -> Math.pow(value, 2))
+                .mapToDouble(Double::valueOf)
+                .sum());
+    }
+
+    private static long getUpperValue(Map<String, Long> hashTagMap, Map<String, Long> pendingHashTagMap, Set<String> totalKeys) {
+        return totalKeys.stream()
+                .map(key -> hashTagMap.getOrDefault(key, 0L) * pendingHashTagMap.getOrDefault(key, 0L))
+                .mapToLong(Long::valueOf)
+                .sum();
+    }
+
+    private static Set<String> getAllKeys(Map<String, Long> hashTagMap, Map<String, Long> pendingHashTagMap) {
+        Set<String> totalHashTagKeys = new HashSet<>();
+        totalHashTagKeys.addAll(hashTagMap.keySet());
+        totalHashTagKeys.addAll(pendingHashTagMap.keySet());
+        return totalHashTagKeys;
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/HashTagMap.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/HashTagMap.java
@@ -44,7 +44,7 @@ public class HashTagMap {
         long upperValue = getUpperValue(getHashTags(), otherHashTags, getAllKeys(getHashTags(), otherHashTags));
         double lowerValue = getHashTagVectorSize(getHashTags()) * getHashTagVectorSize(otherHashTags);
 
-        if(lowerValue == 0) {
+        if (lowerValue == 0) {
             return 0;
         }
         return 1 - (upperValue / lowerValue);

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityService.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityService.java
@@ -1,0 +1,7 @@
+package softeer.wantcar.cartalog.estimate.service;
+
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
+
+public interface SimilarityService {
+    SimilarEstimateResponseDto getSimilarEstimateDtoList(Long estimateId);
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateDto;
-import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
 import softeer.wantcar.cartalog.estimate.repository.EstimateQueryRepository;
 import softeer.wantcar.cartalog.estimate.repository.SimilarityCommandRepository;
@@ -12,6 +11,7 @@ import softeer.wantcar.cartalog.estimate.repository.SimilarityQueryRepository;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ public class SimilarityServiceImpl implements SimilarityService {
     @Override
     public SimilarEstimateResponseDto getSimilarEstimateDtoList(Long estimateId) {
         EstimateOptionListDto estimateOptionIds = estimateQueryRepository.findEstimateOptionIdsByEstimateId(estimateId);
-        if(estimateOptionIds == null) {
+        if (estimateOptionIds == null) {
             return null;
         }
         List<String> totalHashTags = getTotalHashTags(estimateOptionIds);
@@ -135,11 +135,11 @@ public class SimilarityServiceImpl implements SimilarityService {
     private static int getEstimatePrice(List<EstimateInfoDto> estimateInfos, List<EstimateOptionInfoDto> estimateOptionInfos, EstimateInfoDto curEstimateInfo) {
         int totalPrice = curEstimateInfo.getTrimPrice();
         totalPrice += estimateInfos.stream()
-                              .mapToInt(EstimateInfoDto::getModelTypePrice)
-                              .sum();
+                .mapToInt(EstimateInfoDto::getModelTypePrice)
+                .sum();
         totalPrice += estimateOptionInfos.stream()
-                              .mapToInt(EstimateOptionInfoDto::getPrice)
-                              .sum();
+                .mapToInt(EstimateOptionInfoDto::getPrice)
+                .sum();
         return totalPrice;
     }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
@@ -1,0 +1,145 @@
+package softeer.wantcar.cartalog.estimate.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
+import softeer.wantcar.cartalog.estimate.repository.EstimateQueryRepository;
+import softeer.wantcar.cartalog.estimate.repository.SimilarityCommandRepository;
+import softeer.wantcar.cartalog.estimate.repository.SimilarityQueryRepository;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SimilarityServiceImpl implements SimilarityService {
+    private static final int DISPLAY_OPTION_MAX_SIZE = 2;
+    private final SimilarityQueryRepository similarityQueryRepository;
+    private final SimilarityCommandRepository similarityCommandRepository;
+    private final EstimateQueryRepository estimateQueryRepository;
+    private final ModelOptionQueryRepository modelOptionQueryRepository;
+
+    @Override
+    public SimilarEstimateResponseDto getSimilarEstimateDtoList(Long estimateId) {
+        EstimateOptionListDto estimateOptionIds = estimateQueryRepository.findEstimateOptionIdsByEstimateId(estimateId);
+        if(estimateOptionIds == null) {
+            return null;
+        }
+        List<String> totalHashTags = getTotalHashTags(estimateOptionIds);
+
+        List<Long> similarEstimateIds = getSimilarEstimateIds(estimateOptionIds.getTrimId(), totalHashTags);
+        Map<Long, List<EstimateInfoDto>> estimateInfos = getEstimateInfos(similarEstimateIds);
+        Map<Long, List<EstimateOptionInfoDto>> estimateOptionInfos = getEstimateOptionInfos(similarEstimateIds);
+
+        return getSimilarEstimateResponseDto(estimateOptionIds.getAllOptionIds(), estimateInfos, estimateOptionInfos);
+    }
+
+    private List<String> getTotalHashTags(EstimateOptionListDto estimateOptionListDto) {
+        List<String> totalHashTags = new ArrayList<>();
+        totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromOptionsByOptionIds(estimateOptionListDto.getOptionIds()));
+        totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromPackagesByPackageIds(estimateOptionListDto.getPackageIds()));
+        return totalHashTags.stream()
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private List<Long> getSimilarEstimateIds(Long trimId, List<String> hashTags) {
+        HashTagMap hashTagMap = new HashTagMap(hashTags);
+        lazyCalculateHashTagKeys(trimId, hashTagMap);
+        List<String> similarHashTagKeys = similarityQueryRepository.findSimilarHashTagKeysByTrimIdAndHashTagKey(trimId, hashTagMap.getKey());
+        return similarityQueryRepository.findSimilarEstimateIdsByTrimIdAndHashTagKey(trimId, similarHashTagKeys);
+    }
+
+    private Map<Long, List<EstimateOptionInfoDto>> getEstimateOptionInfos(List<Long> similarEstimateIds) {
+        List<EstimateOptionInfoDto> totalEstimateOptions = new ArrayList<>();
+        totalEstimateOptions.addAll(similarityQueryRepository.findSimilarEstimateOptionsByEstimateIds(similarEstimateIds));
+        totalEstimateOptions.addAll(similarityQueryRepository.findSimilarEstimatePackagesBtEstimateIds(similarEstimateIds));
+        return totalEstimateOptions.stream()
+                .collect(Collectors.groupingBy(EstimateOptionInfoDto::getEstimateId));
+    }
+
+    private Map<Long, List<EstimateInfoDto>> getEstimateInfos(List<Long> similarEstimateIds) {
+        return similarityQueryRepository.findSimilarEstimateInfoBydEstimateIds(similarEstimateIds).stream()
+                .collect(Collectors.groupingBy(EstimateInfoDto::getEstimateId));
+    }
+
+    private void lazyCalculateHashTagKeys(Long trimId, HashTagMap hashTagMap) {
+        List<HashTagMap> pendingHashTagMaps =
+                similarityQueryRepository.findPendingHashTagMapByTrimIdAndHashTagKey(trimId, hashTagMap.getKey());
+        if (pendingHashTagMaps.isEmpty()) {
+            return;
+        }
+
+        Map<String, Double> calculatedSimilarities = new HashMap<>();
+        for (HashTagMap pendingHashTagMap : pendingHashTagMaps) {
+            calculatedSimilarities.put(pendingHashTagMap.getKey(), hashTagMap.getSimilarity(pendingHashTagMap));
+        }
+
+        similarityCommandRepository.deletePending(trimId, hashTagMap.getKey());
+        similarityCommandRepository.savePendingToOther(trimId, hashTagMap.getKey(), new ArrayList<>(calculatedSimilarities.keySet()));
+        similarityCommandRepository.saveCalculatedHashTagKeys(trimId, hashTagMap.getKey(), calculatedSimilarities);
+    }
+
+    private static SimilarEstimateResponseDto getSimilarEstimateResponseDto(List<String> optionIds,
+                                                                            Map<Long, List<EstimateInfoDto>> estimateInfos,
+                                                                            Map<Long, List<EstimateOptionInfoDto>> estimateOptionInfos) {
+        List<SimilarEstimateDto> estimateDtoList = new ArrayList<>();
+        for (Long estimateId : estimateInfos.keySet()) {
+            SimilarEstimateDto estimateDto = getSimilarEstimateDto(optionIds, estimateInfos.get(estimateId), estimateOptionInfos.get(estimateId));
+            estimateDtoList.add(estimateDto);
+        }
+        return SimilarEstimateResponseDto.builder()
+                .similarEstimates(estimateDtoList)
+                .build();
+    }
+
+    private static SimilarEstimateDto getSimilarEstimateDto(List<String> optionIds,
+                                                            List<EstimateInfoDto> estimateInfos,
+                                                            List<EstimateOptionInfoDto> estimateOptionInfos) {
+        EstimateInfoDto curEstimateInfo = estimateInfos.get(0);
+        return SimilarEstimateDto.builder()
+                .detailTrimId(curEstimateInfo.getDetailTrimId())
+                .trimName(curEstimateInfo.getTrimName())
+                .price(getEstimatePrice(estimateInfos, estimateOptionInfos, curEstimateInfo))
+                .modelTypes(getModelTypes(estimateInfos))
+                .exteriorColorCode(curEstimateInfo.getExteriorColorCode())
+                .interiorColorCode(curEstimateInfo.getInteriorColorCode())
+                .nonExistentOptions(getNonExistOptionInfoDtoList(optionIds, estimateOptionInfos))
+                .build();
+    }
+
+    private static List<String> getModelTypes(List<EstimateInfoDto> estimateInfos) {
+        return estimateInfos.stream()
+                .map(EstimateInfoDto::getModelTypeName)
+                .collect(Collectors.toList());
+    }
+
+    private static List<EstimateOptionInfoDto> getNonExistOptionInfoDtoList(List<String> optionIds, List<EstimateOptionInfoDto> estimateOptionInfos) {
+        return estimateOptionInfos.stream()
+                .filter(estimateOptionInfo -> !optionIds.contains(estimateOptionInfo.getOptionId()))
+                .limit(DISPLAY_OPTION_MAX_SIZE)
+                .collect(Collectors.toList());
+    }
+
+    private static int getEstimatePrice(List<EstimateInfoDto> estimateInfos, List<EstimateOptionInfoDto> estimateOptionInfos, EstimateInfoDto curEstimateInfo) {
+        int totalPrice = curEstimateInfo.getTrimPrice();
+        totalPrice += estimateInfos.stream()
+                              .mapToInt(EstimateInfoDto::getModelTypePrice)
+                              .sum();
+        totalPrice += estimateOptionInfos.stream()
+                              .mapToInt(EstimateOptionInfoDto::getPrice)
+                              .sum();
+        return totalPrice;
+    }
+}

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/controller/ModelController.java
@@ -62,7 +62,7 @@ public class ModelController {
     public ResponseEntity<EstimateImageDto> findSideExteriorAndInteriorImage(@RequestParam("exteriorColorCode") String exteriorColorCode,
                                                                              @RequestParam("interiorColorCode") String interiorColorCode) {
         EstimateImageDto estimateImageDto = modelQueryRepository.findCarSideExteriorAndInteriorImage(exteriorColorCode, interiorColorCode);
-        if(estimateImageDto == null) {
+        if (estimateImageDto == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(estimateImageDto, HttpStatus.OK);

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepository.java
@@ -9,4 +9,8 @@ public interface ModelOptionQueryRepository {
     ModelTypeListResponseDto findByModelTypeOptionsByTrimId(Long trimId);
 
     List<String> findModelTypeCategoriesByIds(List<Long> modelTypeIds);
+
+    List<String> findHashTagFromOptionsByOptionIds(List<Long> optionIds);
+
+    List<String> findHashTagFromPackagesByPackageIds(List<Long> packageIds);
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImpl.java
@@ -136,4 +136,17 @@ public class ModelOptionQueryRepositoryImpl implements ModelOptionQueryRepositor
         return builder.build();
     }
 
+    @Override
+    public List<String> findHashTagFromOptionsByOptionIds(List<Long> optionIds) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("optionIds", optionIds);
+        return jdbcTemplate.queryForList(QueryString.findHashTagFromOptionsByOptionIds, parameters, String.class);
+    }
+
+    @Override
+    public List<String> findHashTagFromPackagesByPackageIds(List<Long> packageIds) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("packageIds", packageIds);
+        return jdbcTemplate.queryForList(QueryString.findHashTagFromPackagesByPackageIds, parameters, String.class);
+    }
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/model/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/model/repository/QueryString.java
@@ -32,4 +32,18 @@ public class QueryString {
             "FROM model_exterior_colors AS mec " +
             "JOIN model_interior_colors AS mic ON mic.code= :interiorColorCode " +
             "WHERE mec.color_code= :exteriorColorCode ";
+
+    protected static final String findHashTagFromOptionsByOptionIds =
+            "SELECT " +
+            "   moht.hash_tag " +
+            "FROM model_options AS mo " +
+            "JOIN model_option_hash_tags AS moht ON moht.model_option_id=mo.id " +
+            "WHERE mo.id IN (:optionIds) ";
+
+    protected static final String findHashTagFromPackagesByPackageIds =
+            "SELECT " +
+            "   mpht.hash_tag " +
+            "FROM model_packages AS mp " +
+            "JOIN model_package_hash_tags AS mpht ON mpht.model_package_id=mp.id " +
+            "WHERE mp.id IN (:packageIds) ";
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/trim/service/TrimOptionService.java
@@ -6,6 +6,8 @@ import softeer.wantcar.cartalog.trim.dto.TrimPackageDetailResponseDto;
 
 public interface TrimOptionService {
     TrimOptionListResponseDto getTrimOptionList(Long detailTrimId, String interiorColorCode);
+
     TrimOptionDetailResponseDto getTrimOptionDetail(Long detailTrimOptionId);
+
     TrimPackageDetailResponseDto getTrimPackageDetail(Long packageId);
 }

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/controller/EstimateControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/controller/EstimateControllerTest.java
@@ -12,8 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import softeer.wantcar.cartalog.estimate.repository.EstimateQueryRepository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/controller/SimilarityControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/controller/SimilarityControllerTest.java
@@ -1,0 +1,68 @@
+package softeer.wantcar.cartalog.estimate.controller;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
+import softeer.wantcar.cartalog.estimate.service.SimilarityService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@DisplayName("유사 견적 관련 Controller 테스트")
+class SimilarityControllerTest {
+    SimilarityService similarityService;
+    SimilarityController similarityController;
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setUp() {
+        similarityService = mock(SimilarityService.class);
+        similarityController = new SimilarityController(similarityService);
+        softAssertions = new SoftAssertions();
+    }
+
+    @Nested
+    @DisplayName("findSimilarEstimates 테스트")
+    class findSimilarEstimatesTest {
+        @Test
+        @DisplayName("존재하는 견적 식별자를 전달하면 200 상태와 함께 유사 견적들을 반환해야 한다")
+        void returnStatus200AndSimilarEstimates() {
+            //given
+            SimilarEstimateResponseDto expectResponse = SimilarEstimateResponseDto.builder()
+                    .similarEstimates(List.of())
+                    .build();
+            when(similarityService.getSimilarEstimateDtoList(anyLong()))
+                    .thenReturn(expectResponse);
+
+            //when
+            ResponseEntity<SimilarEstimateResponseDto> actualResponse = similarityController.findSimilarEstimates(1L);
+
+            //then
+            softAssertions.assertThat(actualResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+            softAssertions.assertThat(actualResponse.getBody()).isEqualTo(expectResponse);
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 견적 식별자를 전달하면 404 상태를 반환한다")
+        void return404() {
+            //given
+            when(similarityService.getSimilarEstimateDtoList(anyLong()))
+                    .thenReturn(null);
+
+            //when
+            ResponseEntity<SimilarEstimateResponseDto> actualResponse = similarityController.findSimilarEstimates(1L);
+
+            //then
+            softAssertions.assertThat(actualResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            softAssertions.assertThat(actualResponse.getBody()).isNull();
+            softAssertions.assertAll();
+        }
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
@@ -1,0 +1,70 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DisplayName("견적 Repository 테스트")
+@JdbcTest
+@Transactional
+@Sql({"classpath:schema.sql"})
+class EstimateQueryRepositoryTest {
+    @Autowired
+    NamedParameterJdbcTemplate jdbcTemplate;
+    EstimateQueryRepository estimateQueryRepository;
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setUp() {
+        estimateQueryRepository = new EstimateQueryRepositoryImpl(jdbcTemplate);
+        softAssertions = new SoftAssertions();
+    }
+    @Nested
+    @DisplayName("findEstimateOptionIdsByEstimateId 테스트")
+    class findEstimateOptionIdsByEstimateIdTest {
+        @Test
+        @DisplayName("존재하는 견적 식별자를 전달할 경우, 견적의 트림 식별자, 선택 옵션 식별자 목록, 패키지 식별자 목록을 반환한다")
+        void returnEstimateInfo() {
+            //given
+            //when
+            EstimateOptionListDto estimateInfo = estimateQueryRepository.findEstimateOptionIdsByEstimateId(1L);
+
+            //then
+            softAssertions.assertThat(estimateInfo).isNotNull();
+            softAssertions.assertThat(estimateInfo.getOptionIds()).isNotNull();
+            softAssertions.assertThat(estimateInfo.getPackageIds()).isNotNull();
+            List<Character> prefixes = estimateInfo.getAllOptionIds().stream()
+                    .map(id -> id.charAt(0))
+                    .distinct()
+                    .collect(Collectors.toList());
+            softAssertions.assertThat(prefixes.size())
+                    .isLessThanOrEqualTo(2);
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 견적 식별자를 전달할 경우 null을 반환한다")
+        void returnNull() {
+            //given
+            //when
+            EstimateOptionListDto estimateInfo = estimateQueryRepository.findEstimateOptionIdsByEstimateId(-1L);
+
+            //then
+            assertThat(estimateInfo).isNull();
+        }
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
@@ -33,6 +33,7 @@ class EstimateQueryRepositoryTest {
         estimateQueryRepository = new EstimateQueryRepositoryImpl(jdbcTemplate);
         softAssertions = new SoftAssertions();
     }
+
     @Nested
     @DisplayName("findEstimateOptionIdsByEstimateId 테스트")
     class findEstimateOptionIdsByEstimateIdTest {

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryTest.java
@@ -1,0 +1,115 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+@DisplayName("유사 견적 관련 Command Repository 테스트")
+@Transactional
+@JdbcTest
+@Sql({"classpath:schema.sql"})
+class SimilarityCommandRepositoryTest {
+    @Autowired
+    NamedParameterJdbcTemplate jdbcTemplate;
+    SimilarityCommandRepository similarityCommandRepository;
+    SoftAssertions softAssertions;
+    Long leblancId;
+
+    @BeforeEach
+    void setUp() {
+        similarityCommandRepository = new SimilarityCommandRepositoryImpl(jdbcTemplate);
+        softAssertions = new SoftAssertions();
+        leblancId = jdbcTemplate.queryForObject("SELECT id FROM trims WHERE name='Le Blanc'", new HashMap<>(), Long.class);
+    }
+
+    @Nested
+    @DisplayName("savePendingToOther 테스트")
+    class savePendingToOtherTest {
+        @Test
+        @DisplayName("다른 해시 태그 키들에 현재 키를 추가한다")
+        void addCurrentKeyToOtherHashTagKeys() {
+            //given
+            //when
+            similarityCommandRepository.savePendingToOther(leblancId, "a:1|b:1", List.of("b:1|c:1", "b:2|c:2", "b:3|c:3"));
+
+            //then
+            List<String> hashTagKeys = jdbcTemplate.queryForList(
+                    "SELECT pending_hash_tag_left_key FROM pending_hash_tag_similarities WHERE hash_tag_key = 'a:1|b:1' ",
+                    new HashMap<>(), String.class);
+            softAssertions.assertThat(hashTagKeys.size()).isEqualTo(3);
+            softAssertions.assertThat(hashTagKeys).containsAll(
+                    List.of("b:1|c:1", "b:2|c:2", "b:3|c:3"));
+            softAssertions.assertAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("deletePending 테스트")
+    class deletePendingTest {
+        @Test
+        @DisplayName("보류되었던 해시 태그 키(similarities)들을 key의 보류 목록에서 삭제한다")
+        void deletePendingList() {
+            //given
+            jdbcTemplate.update("INSERT INTO pending_hash_tag_similarities " +
+                                "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES " +
+                                "('b:1|c:1', 'a:1|b:1', :trimId), " +
+                                "('b:2|c:2', 'a:1|b:1', :trimId), " +
+                                "('b:3|c:3', 'a:1|b:1', :trimId), " +
+                                "('b:4|c:4', 'a:1|b:1', :trimId), " +
+                                "('b:5|c:5', 'a:1|b:1', :trimId), " +
+                                "('b:6|c:6', 'a:2|b:2', :trimId) ",
+                    new MapSqlParameterSource().addValue("trimId", leblancId));
+
+            //when
+            similarityCommandRepository.deletePending(leblancId, "a:1|b:1");
+
+            //then
+            List<String> hashTagKeys = jdbcTemplate.queryForList(
+                    "SELECT pending_hash_tag_left_key FROM pending_hash_tag_similarities ",
+                    new HashMap<>(), String.class);
+            assertThat(hashTagKeys).isNotNull();
+            assertThat(hashTagKeys.size()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("saveCalculatedHashTagKeys 테스트")
+    class saveCalculatedHashTagKeysTest {
+        @Test
+        @DisplayName("계산된 해시 태그 키(similarities)들을 계산된 목록에 추가한다")
+        void addSimilaritiesToCalculatedList() {
+            //given
+            Map<String, Double> similarities = new HashMap<>();
+            similarities.put("b:1|c:1", 0.5);
+            similarities.put("b:2|c:2", 0.1);
+            similarities.put("b:3|c:3", 0.9);
+            similarities.put("b:4|c:4", 0.7);
+
+            //when
+            similarityCommandRepository.saveCalculatedHashTagKeys(leblancId, "a:1|b:1", similarities);
+
+            //then
+            List<String> hashTagKeys = jdbcTemplate.queryForList("SELECT hash_tag_left_key FROM hash_tag_similarities ",
+                    new HashMap<>(), String.class);
+            softAssertions.assertThat(hashTagKeys).isNotNull();
+            softAssertions.assertThat(hashTagKeys.size()).isEqualTo(4);
+            softAssertions.assertAll();
+        }
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityCommandRepositoryTest.java
@@ -67,13 +67,13 @@ class SimilarityCommandRepositoryTest {
         void deletePendingList() {
             //given
             jdbcTemplate.update("INSERT INTO pending_hash_tag_similarities " +
-                                "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES " +
-                                "('b:1|c:1', 'a:1|b:1', :trimId), " +
-                                "('b:2|c:2', 'a:1|b:1', :trimId), " +
-                                "('b:3|c:3', 'a:1|b:1', :trimId), " +
-                                "('b:4|c:4', 'a:1|b:1', :trimId), " +
-                                "('b:5|c:5', 'a:1|b:1', :trimId), " +
-                                "('b:6|c:6', 'a:2|b:2', :trimId) ",
+                            "(pending_hash_tag_left_key, hash_tag_key, trim_id) VALUES " +
+                            "('b:1|c:1', 'a:1|b:1', :trimId), " +
+                            "('b:2|c:2', 'a:1|b:1', :trimId), " +
+                            "('b:3|c:3', 'a:1|b:1', :trimId), " +
+                            "('b:4|c:4', 'a:1|b:1', :trimId), " +
+                            "('b:5|c:5', 'a:1|b:1', :trimId), " +
+                            "('b:6|c:6', 'a:2|b:2', :trimId) ",
                     new MapSqlParameterSource().addValue("trimId", leblancId));
 
             //when

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryTest.java
@@ -1,0 +1,277 @@
+package softeer.wantcar.cartalog.estimate.repository;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("ALL")
+@DisplayName("유사 견적 관련 Repository 테스트")
+@Transactional
+@JdbcTest
+@Sql({"classpath:schema.sql"})
+class SimilarityQueryRepositoryTest {
+    @Autowired
+    NamedParameterJdbcTemplate jdbcTemplate;
+    SimilarityQueryRepository similarityQueryRepository;
+    SoftAssertions softAssertions;
+    Long leblancId;
+
+    @BeforeEach
+    void setUp() {
+        similarityQueryRepository = new SimilarityQueryRepositoryImpl(jdbcTemplate);
+        softAssertions = new SoftAssertions();
+        leblancId = jdbcTemplate.queryForObject("SELECT id FROM trims WHERE name='Le Blanc'", new HashMap<>(), Long.class);
+    }
+
+    @Nested
+    @DisplayName("findPendingHashTagKeyByTrimIdAndHashTagKey 테스트")
+    class findPendingHashTagKeyByTrimIdAndHashTagKeyTest {
+        @BeforeEach
+        void setUp() {
+            SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
+            jdbcTemplate.update("INSERT INTO pending_hash_tag_similarities (hash_tag_key, pending_hash_tag_left_key, trim_id) " +
+                                "VALUES " +
+                                "    ('a:1|b:2', 'c:1|d:1', :trimId), " +
+                                "    ('a:1|b:2', 'c:1|d:2', :trimId), " +
+                                "    ('a:1|b:2', 'c:1|d:3', :trimId) ", parameters);
+
+        }
+
+        @Test
+        @DisplayName("올바른 식별자들을 전달했을 때 계산되어야 하는 해시 태그 키들을 반환한다")
+        void returnHashTagKeysToQueue() {
+            //given
+            //when
+            List<HashTagMap> pendingHashTagKeys =
+                    similarityQueryRepository.findPendingHashTagMapByTrimIdAndHashTagKey(leblancId, "a:1|b:2");
+
+            //then
+            softAssertions.assertThat(pendingHashTagKeys.size()).isEqualTo(3);
+            softAssertions.assertThat(pendingHashTagKeys).containsAll(List.of(
+                    new HashTagMap("c:1|d:1"),
+                    new HashTagMap("c:1|d:2"),
+                    new HashTagMap("c:1|d:3")));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 식별자를 전달했을 때 빈 Queue를 반환한다")
+        void returnEmptyQueue() {
+            //given
+            //when
+            List<HashTagMap> nonExistTrimIdResult =
+                    similarityQueryRepository.findPendingHashTagMapByTrimIdAndHashTagKey(-1L, "a:1|b:2");
+            List<HashTagMap> nonExistHashTagKeyResult =
+                    similarityQueryRepository.findPendingHashTagMapByTrimIdAndHashTagKey(leblancId, "NOT-EXIST");
+
+            //then
+            softAssertions.assertThat(nonExistTrimIdResult.isEmpty()).isTrue();
+            softAssertions.assertThat(nonExistHashTagKeyResult.isEmpty()).isTrue();
+            softAssertions.assertAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarHashTagKeysByTrimIdAndHashTagKey 테스트")
+    class findSimilarHashTagKeysByTrimIdAndHashTagKeyTest {
+        @BeforeEach
+        void setUp() {
+            SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
+            jdbcTemplate.update("INSERT INTO hash_tag_similarities (hash_tag_key, hash_tag_left_key, trim_id, similarity) " +
+                                "VALUES " +
+                                "    ('a:1|b:2', 'c:1|d:1', :trimId, 0.5), " +
+                                "    ('a:1|b:2', 'c:1|d:2', :trimId, 0.4), " +
+                                "    ('a:1|b:2', 'c:1|d:3', :trimId, 0.7) ", parameters);
+        }
+
+        @Test
+        @DisplayName("올바른 식별자들을 전달했을 때 계산된 해시 태그 정보들을 List형태로 반환한다")
+        void returnHashTagKeysToList() {
+            //given
+            //when
+            List<String> similarHashTagKeys =
+                    similarityQueryRepository.findSimilarHashTagKeysByTrimIdAndHashTagKey(leblancId, "a:1|b:2");
+
+            //then
+            softAssertions.assertThat(similarHashTagKeys.size()).isEqualTo(3);
+            softAssertions.assertThat(similarHashTagKeys).containsAll(List.of("c:1|d:3", "c:1|d:1", "c:1|d:2"));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 식별자를 전달했을 때 빈 List를 반환한다")
+        void returnEmptyList() {
+            //given
+            //when
+            List<String> similarHashTagKeys =
+                    similarityQueryRepository.findSimilarHashTagKeysByTrimIdAndHashTagKey(leblancId, "a:1,b:2");
+
+            //then
+            assertThat(similarHashTagKeys.isEmpty()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarEstimateIdsByTrimIdAndHashTagKey 테스트")
+    class findSimilarEstimateIdsByTrimIdAndHashTagKeyTest {
+        @BeforeEach
+        void setUp() {
+            SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
+            jdbcTemplate.update("INSERT INTO similar_estimates (hash_tag_key, trim_id, estimate_id) " +
+                                "VALUES " +
+                                "    ('a:1|b:2', :trimId, 1), " +
+                                "    ('a:1|b:2', :trimId, 2), " +
+                                "    ('a:1|b:2', :trimId, 3), " +
+                                "    ('a:1|b:2', :trimId, 4), " +
+                                "    ('a:1|b:2', :trimId, 5) ", parameters);
+        }
+
+        @Test
+        @DisplayName("올바른 식별자들을 전달했을 때 유사 견적들을 최대 4개까지 List형태로 반환한다")
+        void returnHashTagKeysToList() {
+            //given
+            //when
+            List<Long> estimateIds =
+                    similarityQueryRepository.findSimilarEstimateIdsByTrimIdAndHashTagKey(leblancId, List.of("a:1|b:2"));
+
+            //then
+            softAssertions.assertThat(estimateIds).isNotNull();
+            softAssertions.assertThat(estimateIds.size()).isLessThanOrEqualTo(4);
+            softAssertions.assertThat(estimateIds).containsAll(List.of(1L, 2L, 3L, 4L));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 식별자를 전달했을 때 빈 List를 반환한다")
+        void returnEmptyList() {
+            //given
+            //when
+            List<Long> notExistTrimId =
+                    similarityQueryRepository.findSimilarEstimateIdsByTrimIdAndHashTagKey(-1L, List.of("a:1|b:2"));
+            List<Long> notExistHashTagKey =
+                    similarityQueryRepository.findSimilarEstimateIdsByTrimIdAndHashTagKey(leblancId, List.of("NOT-EXIST"));
+
+            //then
+            softAssertions.assertThat(notExistTrimId.isEmpty()).isTrue();
+            softAssertions.assertThat(notExistHashTagKey.isEmpty()).isTrue();
+            softAssertions.assertAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarEstimateInfoBydEstimateIds 테스트")
+    class findSimilarEstimateInfoBydEstimateIdsTest {
+        @Test
+        @DisplayName("견적 식별자 목록에 존재하는 견적 정보를 반환한다")
+        void returnEstimateInfos() {
+            //given
+            //when
+            List<EstimateInfoDto> estimateInfos =
+                    similarityQueryRepository.findSimilarEstimateInfoBydEstimateIds(List.of(1L, 2L, 3L));
+
+            //then
+            Map<Long, List<EstimateInfoDto>> mappedEstimateInfos = estimateInfos.stream()
+                    .collect(Collectors.groupingBy(EstimateInfoDto::getEstimateId));
+            softAssertions.assertThat(mappedEstimateInfos.keySet().size()).isEqualTo(3);
+            softAssertions.assertThat(mappedEstimateInfos.keySet()).containsAll(List.of(1L, 2L, 3L));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("견적 식별자 목록의 모든 식별자가 존재하지 않는다면 빈 리스트를 반환한다")
+        void returnEmptyList() {
+            //given
+            //when
+            List<EstimateInfoDto> estimateInfos =
+                    similarityQueryRepository.findSimilarEstimateInfoBydEstimateIds(List.of(-1L));
+
+            //then
+            assertThat(estimateInfos.isEmpty()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarEstimateOptionsByEstimateIds 테스트")
+    class findSimilarEstimateOptionsByEstimateIdsTest {
+        @Test
+        @DisplayName("견적 식별자 목록에 존재하는 견적 선택 옵션 정보를 반환한다")
+        void returnSelectiveOptionInfos() {
+            //given
+            //when
+            //TODO: 3, 4이 아니거나, 데이터가 변경될 경우 실패 가능
+            List<EstimateOptionInfoDto> estimateOptions =
+                    similarityQueryRepository.findSimilarEstimateOptionsByEstimateIds(List.of(3L, 4L));
+
+            //then
+            Map<Long, List<EstimateOptionInfoDto>> mappedEstimateOptionInfos = estimateOptions.stream()
+                    .collect(Collectors.groupingBy(EstimateOptionInfoDto::getEstimateId));
+            softAssertions.assertThat(mappedEstimateOptionInfos.keySet().size()).isEqualTo(2);
+            softAssertions.assertThat(mappedEstimateOptionInfos.keySet()).containsAll(List.of(3L, 4L));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("견적 식별자 목록의 모든 식별자가 존재하지 않는다면 빈 리스트를 반환한다")
+        void returnEmptyList() {
+            //given
+            //when
+            List<EstimateOptionInfoDto> estimateOptions =
+                    similarityQueryRepository.findSimilarEstimateOptionsByEstimateIds(List.of(-1L));
+
+            //then
+            assertThat(estimateOptions.isEmpty()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarEstimatePackagesBtEstimateIds 테스트")
+    class findSimilarEstimatePackagesBtEstimateIdsTest {
+        @Test
+        @DisplayName("견적 식별자 목록에 존재하는 견적 패키지 정보를 반환한다")
+        void returnSelectivePackageInfos() {
+            //given
+            //when
+            //TODO: 1, 3이 아니거나, 데이터가 변경될 경우 실패 가능
+            List<EstimateOptionInfoDto> estimatePackages =
+                    similarityQueryRepository.findSimilarEstimatePackagesBtEstimateIds(List.of(1L, 3L));
+
+            //then
+            Map<Long, List<EstimateOptionInfoDto>> mappedEstimatePackageInfos = estimatePackages.stream()
+                    .collect(Collectors.groupingBy(EstimateOptionInfoDto::getEstimateId));
+            softAssertions.assertThat(mappedEstimatePackageInfos.keySet().size()).isEqualTo(2);
+            softAssertions.assertThat(mappedEstimatePackageInfos.keySet()).containsAll(List.of(1L, 3L));
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("견적 식별자 목록의 모든 식별자가 존재하지 않는다면 빈 리스트를 반환한다")
+        void returnEmptyList() {
+            //given
+            //when
+            List<EstimateOptionInfoDto> estimatePackages =
+                    similarityQueryRepository.findSimilarEstimatePackagesBtEstimateIds(List.of(-1L));
+
+            //then
+            assertThat(estimatePackages.isEmpty()).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/SimilarityQueryRepositoryTest.java
@@ -12,9 +12,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
-import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 
 import java.util.HashMap;
 import java.util.List;
@@ -49,10 +49,10 @@ class SimilarityQueryRepositoryTest {
         void setUp() {
             SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
             jdbcTemplate.update("INSERT INTO pending_hash_tag_similarities (hash_tag_key, pending_hash_tag_left_key, trim_id) " +
-                                "VALUES " +
-                                "    ('a:1|b:2', 'c:1|d:1', :trimId), " +
-                                "    ('a:1|b:2', 'c:1|d:2', :trimId), " +
-                                "    ('a:1|b:2', 'c:1|d:3', :trimId) ", parameters);
+                    "VALUES " +
+                    "    ('a:1|b:2', 'c:1|d:1', :trimId), " +
+                    "    ('a:1|b:2', 'c:1|d:2', :trimId), " +
+                    "    ('a:1|b:2', 'c:1|d:3', :trimId) ", parameters);
 
         }
 
@@ -97,10 +97,10 @@ class SimilarityQueryRepositoryTest {
         void setUp() {
             SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
             jdbcTemplate.update("INSERT INTO hash_tag_similarities (hash_tag_key, hash_tag_left_key, trim_id, similarity) " +
-                                "VALUES " +
-                                "    ('a:1|b:2', 'c:1|d:1', :trimId, 0.5), " +
-                                "    ('a:1|b:2', 'c:1|d:2', :trimId, 0.4), " +
-                                "    ('a:1|b:2', 'c:1|d:3', :trimId, 0.7) ", parameters);
+                    "VALUES " +
+                    "    ('a:1|b:2', 'c:1|d:1', :trimId, 0.5), " +
+                    "    ('a:1|b:2', 'c:1|d:2', :trimId, 0.4), " +
+                    "    ('a:1|b:2', 'c:1|d:3', :trimId, 0.7) ", parameters);
         }
 
         @Test
@@ -137,12 +137,12 @@ class SimilarityQueryRepositoryTest {
         void setUp() {
             SqlParameterSource parameters = new MapSqlParameterSource().addValue("trimId", leblancId);
             jdbcTemplate.update("INSERT INTO similar_estimates (hash_tag_key, trim_id, estimate_id) " +
-                                "VALUES " +
-                                "    ('a:1|b:2', :trimId, 1), " +
-                                "    ('a:1|b:2', :trimId, 2), " +
-                                "    ('a:1|b:2', :trimId, 3), " +
-                                "    ('a:1|b:2', :trimId, 4), " +
-                                "    ('a:1|b:2', :trimId, 5) ", parameters);
+                    "VALUES " +
+                    "    ('a:1|b:2', :trimId, 1), " +
+                    "    ('a:1|b:2', :trimId, 2), " +
+                    "    ('a:1|b:2', :trimId, 3), " +
+                    "    ('a:1|b:2', :trimId, 4), " +
+                    "    ('a:1|b:2', :trimId, 5) ", parameters);
         }
 
         @Test

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
@@ -62,7 +62,6 @@ class SimilarityServiceTest {
                     similarityService.getSimilarEstimateDtoList(1L);
 
             //then
-            //TODO: 테스트 추가 필요
             softAssertions.assertThat(similarEstimateResponseDto).isNotNull();
             List<SimilarEstimateDto> similarEstimates =
                     similarEstimateResponseDto.getSimilarEstimates();

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateDto;
-import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
 import softeer.wantcar.cartalog.estimate.repository.EstimateQueryRepository;
 import softeer.wantcar.cartalog.estimate.repository.SimilarityCommandRepository;
@@ -14,13 +13,14 @@ import softeer.wantcar.cartalog.estimate.repository.SimilarityQueryRepository;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
 import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
 import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceTest.java
@@ -1,0 +1,147 @@
+package softeer.wantcar.cartalog.estimate.service;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.HashTagMap;
+import softeer.wantcar.cartalog.estimate.dto.SimilarEstimateResponseDto;
+import softeer.wantcar.cartalog.estimate.repository.EstimateQueryRepository;
+import softeer.wantcar.cartalog.estimate.repository.SimilarityCommandRepository;
+import softeer.wantcar.cartalog.estimate.repository.SimilarityQueryRepository;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionInfoDto;
+import softeer.wantcar.cartalog.estimate.repository.dto.EstimateOptionListDto;
+import softeer.wantcar.cartalog.model.repository.ModelOptionQueryRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("유사 견적 서비스 테스트")
+class SimilarityServiceTest {
+    SimilarityService similarityService;
+    SimilarityCommandRepository similarityCommandRepository;
+    SimilarityQueryRepository similarityQueryRepository;
+    EstimateQueryRepository estimateQueryRepository;
+    ModelOptionQueryRepository modelOptionQueryRepository;
+
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setUp() {
+        modelOptionQueryRepository = mock(ModelOptionQueryRepository.class);
+        estimateQueryRepository = mock(EstimateQueryRepository.class);
+        similarityQueryRepository = mock(SimilarityQueryRepository.class);
+        similarityCommandRepository = mock(SimilarityCommandRepository.class);
+        similarityService = new SimilarityServiceImpl(similarityQueryRepository, similarityCommandRepository,
+                estimateQueryRepository, modelOptionQueryRepository);
+        softAssertions = new SoftAssertions();
+    }
+
+    @Nested
+    @DisplayName("getSimilarEstimateDtoList 테스트")
+    class getSimilarEstimateDtoListTest {
+        @Test
+        @DisplayName("존재하는 견적 식별자를 전달했을 때 유사 견적 목록을 반환한다")
+        void returnSimilarEstimatesList() {
+            //given
+            mockFindEstimateInfo();
+            mockLazyCalculate();
+            mockFindSimilarEstimates();
+
+            //when
+            SimilarEstimateResponseDto similarEstimateResponseDto =
+                    similarityService.getSimilarEstimateDtoList(1L);
+
+            //then
+            //TODO: 테스트 추가 필요
+            softAssertions.assertThat(similarEstimateResponseDto).isNotNull();
+            List<SimilarEstimateDto> similarEstimates =
+                    similarEstimateResponseDto.getSimilarEstimates();
+            softAssertions.assertThat(similarEstimates.size()).isEqualTo(2);
+            softAssertions.assertThat(similarEstimates.stream()
+                    .map(SimilarEstimateDto::getPrice)
+                    .collect(Collectors.toList())).contains(130);
+            softAssertions.assertAll();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 견적 식별자를 전달할 경우 null을 반환한다")
+        void returnNull() {
+            //given
+            when(estimateQueryRepository.findEstimateOptionIdsByEstimateId(anyLong()))
+                    .thenReturn(null);
+            //when
+            SimilarEstimateResponseDto similarEstimateDtoList = similarityService.getSimilarEstimateDtoList(1L);
+
+            //then
+            assertThat(similarEstimateDtoList).isNull();
+        }
+
+        private void mockFindEstimateInfo() {
+            when(estimateQueryRepository.findEstimateOptionIdsByEstimateId(anyLong()))
+                    .thenReturn(new EstimateOptionListDto(1L, new ArrayList<>(), new ArrayList<>()));
+            when(modelOptionQueryRepository.findHashTagFromOptionsByOptionIds(anyList()))
+                    .thenReturn(List.of("a"));
+            when(modelOptionQueryRepository.findHashTagFromPackagesByPackageIds(anyList()))
+                    .thenReturn(List.of("b"));
+        }
+
+        private void mockFindSimilarEstimates() {
+            when(similarityQueryRepository.findSimilarEstimateInfoBydEstimateIds(anyList()))
+                    .thenReturn(List.of(
+                            getEstimateInfoDto(1L, "A"),
+                            getEstimateInfoDto(2L, "A"),
+                            getEstimateInfoDto(2L, "B")));
+            when(similarityQueryRepository.findSimilarEstimateOptionsByEstimateIds(anyList()))
+                    .thenReturn(List.of(
+                            getEstimateOptionIfo(1L, 1L, true),
+                            getEstimateOptionIfo(1L, 2L, true),
+                            getEstimateOptionIfo(2L, 3L, true)));
+            when(similarityQueryRepository.findSimilarEstimatePackagesBtEstimateIds(anyList()))
+                    .thenReturn(List.of(getEstimateOptionIfo(2L, 1L, false)));
+        }
+
+        private void mockLazyCalculate() {
+            when(similarityQueryRepository.findPendingHashTagMapByTrimIdAndHashTagKey(anyLong(), anyString()))
+                    .thenReturn(List.of(new HashTagMap("a:1|b:1")));
+            when(similarityQueryRepository.findSimilarHashTagKeysByTrimIdAndHashTagKey(anyLong(), anyString()))
+                    .thenReturn(List.of("a:1|b:1", "b:1|c:1", "c:1|d:1"));
+            when(similarityQueryRepository.findSimilarEstimateIdsByTrimIdAndHashTagKey(anyLong(), anyList()))
+                    .thenReturn(List.of(1L, 2L, 3L));
+        }
+    }
+
+    private static EstimateInfoDto getEstimateInfoDto(Long estimateId,
+                                                      String modelTypeName) {
+        return EstimateInfoDto.builder()
+                .estimateId(estimateId)
+                .detailTrimId(9L)
+                .trimName("AAA")
+                .trimPrice(100)
+                .exteriorColorCode("A")
+                .interiorColorCode("B")
+                .modelTypeName(modelTypeName)
+                .modelTypePrice(10)
+                .build();
+    }
+
+    private static EstimateOptionInfoDto getEstimateOptionIfo(Long estimateId, Long optionId, boolean isOption) {
+        String optionPrefix = isOption ? "O" : "P";
+        return EstimateOptionInfoDto.builder()
+                .estimateId(estimateId)
+                .optionId(optionPrefix + optionId)
+                .name(String.valueOf(optionId))
+                .price(10)
+                .imageUrl("imageUrl")
+                .build();
+    }
+}

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
@@ -111,4 +111,57 @@ class ModelOptionQueryRepositoryImplTest {
             assertThat(categories).isNull();
         }
     }
+
+    @SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+    @Nested
+    @DisplayName("findHashTagFromOptionsByOptionIds 테스트")
+    class findHashTagFromOptionsByOptionIdsTest {
+        List<Long> optionIds;
+        @BeforeEach
+        void setUp() {
+            optionIds = jdbcTemplate.queryForList("SELECT mo.id " +
+                                                  "FROM model_option_hash_tags AS moht " +
+                                                  "JOIN model_options AS mo ON mo.id=moht.model_option_id ",
+                    new HashMap<>(), Long.TYPE);
+        }
+
+        @Test
+        @DisplayName("옵션 식별자에 해당하는 해시 태그 목록을 반환한다")
+        void returnHashTagList() {
+            //given
+            //when
+            List<String> hashTags = modelOptionQueryRepository.findHashTagFromOptionsByOptionIds(optionIds);
+
+            //then
+            softAssertions.assertThat(hashTags.isEmpty()).isFalse();
+            softAssertions.assertThat(hashTags.size()).isNotEqualTo(hashTags.stream().distinct().count());
+            softAssertions.assertAll();
+        }
+    }
+
+    @SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+    @Nested
+    @DisplayName("findHashTagFromPackagesByPackageIds 테스트")
+    class findHashTagFromPackagesByPackageIdsTest {
+        List<Long> packageIds;
+        @BeforeEach
+        void setUp() {
+            packageIds = jdbcTemplate.queryForList("SELECT mp.id " +
+                                                   "FROM model_package_hash_tags AS mpht " +
+                                                   "JOIN model_packages AS mp ON mp.id=mpht.model_package_id ",
+                    new HashMap<>(), Long.TYPE);
+        }
+        @Test
+        @DisplayName("패키지 식별자에 해당하는 해시 태그 목록을 반환한다")
+        void returnHashTagList() {
+            //given
+            //when
+            List<String> hashTags = modelOptionQueryRepository.findHashTagFromPackagesByPackageIds(packageIds);
+
+            //then
+            softAssertions.assertThat(hashTags.isEmpty()).isFalse();
+            softAssertions.assertThat(hashTags.size()).isNotEqualTo(hashTags.stream().distinct().count());
+            softAssertions.assertAll();
+        }
+    }
 }

--- a/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/model/repository/ModelOptionQueryRepositoryImplTest.java
@@ -117,11 +117,12 @@ class ModelOptionQueryRepositoryImplTest {
     @DisplayName("findHashTagFromOptionsByOptionIds 테스트")
     class findHashTagFromOptionsByOptionIdsTest {
         List<Long> optionIds;
+
         @BeforeEach
         void setUp() {
             optionIds = jdbcTemplate.queryForList("SELECT mo.id " +
-                                                  "FROM model_option_hash_tags AS moht " +
-                                                  "JOIN model_options AS mo ON mo.id=moht.model_option_id ",
+                            "FROM model_option_hash_tags AS moht " +
+                            "JOIN model_options AS mo ON mo.id=moht.model_option_id ",
                     new HashMap<>(), Long.TYPE);
         }
 
@@ -144,13 +145,15 @@ class ModelOptionQueryRepositoryImplTest {
     @DisplayName("findHashTagFromPackagesByPackageIds 테스트")
     class findHashTagFromPackagesByPackageIdsTest {
         List<Long> packageIds;
+
         @BeforeEach
         void setUp() {
             packageIds = jdbcTemplate.queryForList("SELECT mp.id " +
-                                                   "FROM model_package_hash_tags AS mpht " +
-                                                   "JOIN model_packages AS mp ON mp.id=mpht.model_package_id ",
+                            "FROM model_package_hash_tags AS mpht " +
+                            "JOIN model_packages AS mp ON mp.id=mpht.model_package_id ",
                     new HashMap<>(), Long.TYPE);
         }
+
         @Test
         @DisplayName("패키지 식별자에 해당하는 해시 태그 목록을 반환한다")
         void returnHashTagList() {

--- a/backend/src/test/resources/csv/similar_estimates.csv
+++ b/backend/src/test/resources/csv/similar_estimates.csv
@@ -1,1 +1,1 @@
-hash_tag_key|estimate_id
+hash_tag_key|estimate_id|trim_id

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -304,8 +304,10 @@ CREATE TABLE similar_estimates
 (
     hash_tag_key VARCHAR(255),
     estimate_id  BIGINT,
-    PRIMARY KEY (hash_tag_key, estimate_id),
-    FOREIGN KEY (estimate_id) REFERENCES estimates (id) ON UPDATE CASCADE
+    trim_id      BIGINT,
+    PRIMARY KEY (hash_tag_key, estimate_id, trim_id),
+    FOREIGN KEY (estimate_id) REFERENCES estimates (id) ON UPDATE CASCADE,
+    FOREIGN KEY (trim_id) REFERENCES trims (id) ON UPDATE CASCADE
 );
 
 CREATE TABLE hash_tag_similarities
@@ -468,7 +470,7 @@ INSERT INTO release_records (id, estimate_id, create_date)
 SELECT *
 FROM CSVREAD('classpath:csv/release_records.csv', null, 'fieldSeparator=|');
 
-INSERT INTO similar_estimates (hash_tag_key, estimate_id)
+INSERT INTO similar_estimates (hash_tag_key, estimate_id, trim_id)
 SELECT *
 FROM CSVREAD('classpath:csv/similar_estimates.csv', null, 'fieldSeparator=|');
 


### PR DESCRIPTION
## 한 일
- [x] 견적 유사도 계산 로직 구현
- [x] 유사 출고 견적 조회 API 구현
- [x] Swagger에 API 설명 추가

close #119 