### PR TITLE
[Front-End] 완료 페이지 Footer 설정 및 상세견적 Tab 조건부 렌더링

### DIFF
--- a/frontend/src/pages/EstimationPage/Detail/DetailCard/DetailTitle/index.jsx
+++ b/frontend/src/pages/EstimationPage/Detail/DetailCard/DetailTitle/index.jsx
@@ -1,10 +1,11 @@
-import * as S from './style';
 import { ReactComponent as ArrowDown } from '../../../../../../assets/icons/arrow_down_24.svg';
+import { TYPE } from '../../../constants';
+import * as S from './style';
 
-function DetailTitle({ expanded, setExpanded, data }) {
-  const price = data?.data
-    ?.reduce((acc, cur) => {
-      return acc + cur.price ?? 0;
+function DetailTitle({ expanded, setExpanded, data, type }) {
+  const price = (data?.data ?? [])
+    .reduce((acc, cur) => {
+      return acc + (cur.price ?? 0);
     }, 0)
     .toLocaleString();
 
@@ -12,7 +13,12 @@ function DetailTitle({ expanded, setExpanded, data }) {
     <S.DetailTitle>
       <S.Title>{data?.title}</S.Title>
       <S.Area>
-        <S.Price>{`+${price} 원`}</S.Price>
+        <S.Price>
+          {type === TYPE.PLUS && `+${price} 원`}
+          {type === TYPE.MINUS && `-${price} 원`}
+          {type === TYPE.PAYMENT && TYPE.PAYMENT_TEXT}
+          {type === TYPE.TAX && TYPE.TAX_MENT}
+        </S.Price>
         <button type="button" onClick={() => setExpanded((prev) => !prev)}>
           <ArrowDown className={expanded ? 'open' : null} />
         </button>

--- a/frontend/src/pages/EstimationPage/Detail/DetailCard/index.jsx
+++ b/frontend/src/pages/EstimationPage/Detail/DetailCard/index.jsx
@@ -12,7 +12,7 @@ function DetailCard({ data }) {
 
   return (
     <S.DetailCard className={expanded ? 'expanded' : null}>
-      <DetailTitle expanded={expanded} setExpanded={setExpanded} data={data} />
+      <DetailTitle expanded={expanded} setExpanded={setExpanded} data={data} type={data.type} />
       <S.DetailContents $n={data?.data?.length}>
         {data?.data?.map((item) => (
           <DetailItem key={`${item.id}${item.name}`} data={item} />

--- a/frontend/src/pages/EstimationPage/Footer/index.jsx
+++ b/frontend/src/pages/EstimationPage/Footer/index.jsx
@@ -1,0 +1,58 @@
+import { useData, TotalPrice } from '../../../utils/Context';
+import { FOOTER } from '../constants';
+import * as S from './style';
+import Button from '../../../components/Button';
+import ImageViewButton from '../../../components/ImageViewButton';
+
+function Footer() {
+  const { price } = useData();
+
+  const shareButtonProps = {
+    type: FOOTER.TYPE,
+    state: FOOTER.INACTIVE,
+    mainTitle: FOOTER.SHARE_TITLE,
+    event: () => {},
+  };
+
+  const pdfButtonProps = {
+    type: FOOTER.TYPE,
+    state: FOOTER.INACTIVE,
+    mainTitle: FOOTER.PDF_TITLE,
+    event: () => {},
+  };
+
+  const counsultButtonProps = {
+    type: FOOTER.TYPE,
+    state: FOOTER.ACTIVE,
+    mainTitle: FOOTER.COUNSULT_TITLE,
+    event: () => {},
+  };
+
+  const imageViewButtonProps = {
+    onClick: () => {},
+    text: FOOTER.CHECK_IMAGE,
+  };
+
+  return (
+    <S.Footer>
+      <S.ImageViewButtonWrapper>
+        <ImageViewButton {...imageViewButtonProps} />
+      </S.ImageViewButtonWrapper>
+
+      <S.TotalPrice>
+        <S.TotalPriceText>{FOOTER.FINAL_PRICE}</S.TotalPriceText>
+        <S.TotalPriceNumber>
+          {TotalPrice(price).toLocaleString('ko-KR')}
+          {FOOTER.WON}
+        </S.TotalPriceNumber>
+      </S.TotalPrice>
+      <S.ButtonWrapper>
+        <Button {...shareButtonProps} />
+        <Button {...pdfButtonProps} />
+        <Button {...counsultButtonProps} />
+      </S.ButtonWrapper>
+    </S.Footer>
+  );
+}
+
+export default Footer;

--- a/frontend/src/pages/EstimationPage/Footer/style.jsx
+++ b/frontend/src/pages/EstimationPage/Footer/style.jsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+export const Footer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1024px;
+  margin: 0 auto;
+`;
+
+export const ImageViewButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 25px;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 17px;
+`;
+
+export const TotalPrice = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 15px;
+  gap: 8px;
+`;
+
+export const TotalPriceText = styled.h2`
+  font: ${({ theme }) => theme.font.headKR.Regular12};
+  color: ${({ theme }) => theme.color.gray['700']};
+`;
+
+export const TotalPriceNumber = styled.h2`
+  font: ${({ theme }) => theme.font.headKR.Medium24};
+  color: ${({ theme }) => theme.color.primary['500']};
+`;

--- a/frontend/src/pages/EstimationPage/Preview/style.jsx
+++ b/frontend/src/pages/EstimationPage/Preview/style.jsx
@@ -52,7 +52,6 @@ const ImageAnimation = keyframes`
 
 export const Preview = styled.div`
   width: 100%;
-  height: 680px;
   background-color: ${({ theme }) => theme.color.white};
 
   & > div {

--- a/frontend/src/pages/EstimationPage/constants.js
+++ b/frontend/src/pages/EstimationPage/constants.js
@@ -33,3 +33,14 @@ export const INFO = {
   DISPLACEMENT_UNIT: 'cc',
   FUELEFFICIENCY_UNIT: 'km/s',
 };
+
+export const TYPE = {
+  PLUS: 'plus',
+  MINUS: 'minus',
+  TEXT: 'text',
+  NONE: 'none',
+  PAYMENT: 'payment',
+  PAYMENT_TEXT: '결제수단을 선택하고 지불조건 및 납입사항을 확인하세요.',
+  TAX: 'tax',
+  TAX_MENT: '할인/포인트 및 결제 방법 선택 후 확인 가능해요.',
+};

--- a/frontend/src/pages/EstimationPage/constants.js
+++ b/frontend/src/pages/EstimationPage/constants.js
@@ -44,3 +44,15 @@ export const TYPE = {
   TAX: 'tax',
   TAX_MENT: '할인/포인트 및 결제 방법 선택 후 확인 가능해요.',
 };
+
+export const FOOTER = {
+  TYPE: 'buttonD',
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  SHARE_TITLE: '공유하기',
+  PDF_TITLE: 'PDF 다운로드',
+  COUNSULT_TITLE: '상담신청',
+  FINAL_PRICE: '최종 견적 가격',
+  CHECK_IMAGE: '이미지 확인',
+  WON: '원',
+};

--- a/frontend/src/pages/EstimationPage/index.jsx
+++ b/frontend/src/pages/EstimationPage/index.jsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 import { useData, TotalPrice } from '../../utils/Context';
 import { ESTIMATION, TYPE } from './constants';
+import * as S from './style';
 import PriceStaticBar from '../../components/PriceStaticBar';
 import Preview from './Preview';
-import * as S from './style';
 import Info from './Info';
 import Detail from './Detail';
 import HMGArea from './HMGArea';
+import Footer from './Footer';
 
 const MOCK_HMGDATA = {
   trim: '르블랑',
@@ -142,7 +143,9 @@ function Estimation() {
           <Detail data={DATA} />
           <HMGArea data={MOCK_HMGDATA} />
         </S.PageContents>
+        <Footer />
       </S.Estimation>
+
       <PriceStaticBar
         min={SelectModel?.minPrice}
         max={SelectModel?.maxPrice}

--- a/frontend/src/pages/EstimationPage/index.jsx
+++ b/frontend/src/pages/EstimationPage/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useData, TotalPrice } from '../../utils/Context';
-import { ESTIMATION } from './constants';
+import { ESTIMATION, TYPE } from './constants';
 import PriceStaticBar from '../../components/PriceStaticBar';
 import Preview from './Preview';
 import * as S from './style';
@@ -55,6 +55,7 @@ function Estimation() {
   const DATA = [
     {
       title: ESTIMATION.DATA.MODEL_TYPE,
+      type: TYPE.PLUS,
       expand: true,
       data: [
         {
@@ -79,6 +80,7 @@ function Estimation() {
     },
     {
       title: ESTIMATION.DATA.COLOR,
+      type: TYPE.PLUS,
       expand: true,
       data: [
         {
@@ -97,6 +99,7 @@ function Estimation() {
     },
     {
       title: ESTIMATION.DATA.OPTION,
+      type: TYPE.PLUS,
       expand: optionPicker.isExpend,
       data: [
         ...optionPicker.chosenOptionsData.map((optionData, index) => ({
@@ -107,10 +110,10 @@ function Estimation() {
         })),
       ],
     },
-    { title: ESTIMATION.DATA.CONSIGNMENT },
-    { title: ESTIMATION.DATA.DISCOUNT_AND_POINT },
-    { title: ESTIMATION.DATA.PAYMENT },
-    { title: ESTIMATION.DATA.TAX_AND_ENROLL },
+    { title: ESTIMATION.DATA.CONSIGNMENT, type: TYPE.MINUS },
+    { title: ESTIMATION.DATA.DISCOUNT_AND_POINT, type: TYPE.MINUS },
+    { title: ESTIMATION.DATA.PAYMENT, type: TYPE.PAYMENT },
+    { title: ESTIMATION.DATA.TAX_AND_ENROLL, type: TYPE.TAX },
     { title: ESTIMATION.DATA.INFO },
   ];
 

--- a/frontend/src/pages/EstimationPage/style.jsx
+++ b/frontend/src/pages/EstimationPage/style.jsx
@@ -6,6 +6,10 @@ export const Estimation = styled.div`
   height: 100vh;
   box-sizing: border-box;
   overflow: scroll;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const PageContents = styled.div`


### PR DESCRIPTION
## Change
- 완료 페이지 Footer 버튼 설정 
- 상세견적 Tab 조건부 렌더링 적용

## Problem
이미지 확인 버튼에서 상단으로 가지 않는 문제

```js
 const imageViewButtonProps = {
    onClick: () => {
      console.log('click');
      window.scrollTo({
        top: 0,
        behavior: 'smooth',
      });
    },
    text: FOOTER.CHECK_IMAGE,
  };
```

## Issue
- #363 