### PR TITLE
[Front-End] Popup 컴포넌트, 헤더 Logo, Exit 버그 수정

### DIFF
--- a/frontend/src/components/Header/Exit/index.jsx
+++ b/frontend/src/components/Header/Exit/index.jsx
@@ -12,7 +12,7 @@ function Exit() {
 
   const popupProps = {
     show,
-    close: { handleClose },
+    close: handleClose,
     actions: [
       {
         secondary: true,
@@ -29,11 +29,13 @@ function Exit() {
   };
 
   return (
-    <S.Exit onClick={handleShow}>
-      <S.Text>{EXIT.TEXT}</S.Text>
-      <Cancel />
+    <>
+      <S.Exit onClick={handleShow}>
+        <S.Text>{EXIT.TEXT}</S.Text>
+        <Cancel />
+      </S.Exit>
       <Popup {...popupProps} />
-    </S.Exit>
+    </>
   );
 }
 

--- a/frontend/src/components/Header/Logo/index.jsx
+++ b/frontend/src/components/Header/Logo/index.jsx
@@ -12,7 +12,7 @@ function Logo() {
 
   const popupProps = {
     show,
-    close: { handleClose },
+    close: handleClose,
     actions: [
       {
         secondary: true,
@@ -29,18 +29,20 @@ function Logo() {
   };
 
   return (
-    <S.Logo>
-      <S.LogoWrapper onClick={handleShow}>
-        <HyundaiLogo />
-      </S.LogoWrapper>
+    <>
+      <S.Logo>
+        <S.LogoWrapper onClick={handleShow}>
+          <HyundaiLogo />
+        </S.LogoWrapper>
 
-      <S.Line />
-      <S.CarType>
-        <S.Type>{LOGO.TYPE}</S.Type>
-        <ArrowDown />
-      </S.CarType>
+        <S.Line />
+        <S.CarType>
+          <S.Type>{LOGO.TYPE}</S.Type>
+          <ArrowDown />
+        </S.CarType>
+      </S.Logo>
       <Popup {...popupProps} />
-    </S.Logo>
+    </>
   );
 }
 

--- a/frontend/src/components/Popup/index.jsx
+++ b/frontend/src/components/Popup/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as S from './style';
+import { createPortal } from 'react-dom';
 
 function Popup({ show, close, actions, children }) {
   const actionButtons = actions.map((child) => {
@@ -24,14 +25,16 @@ function Popup({ show, close, actions, children }) {
     );
   });
   return (
-    show && (
+    show &&
+    createPortal(
       <>
         <S.Overlay onClick={close} />
         <S.Popup>
           <S.PopupContent>{children}</S.PopupContent>
           <S.PopupActions>{actionButtons}</S.PopupActions>
         </S.Popup>
-      </>
+      </>,
+      document.querySelector('#modal'),
     )
   );
 }


### PR DESCRIPTION
# Changes

* Popup 컴포넌트의 overlay가 일부 컴포넌트를 가리지 않는 문제 수정
* 헤더의 Logo, Exit를 통해 열린 Popup의 close가 동작하지 않는 문제 수정

# Related Issues

* Close #390 
