### PR TITLE
[Front-End] history로 뒤로가기 이벤트 추가

### DIFF
--- a/frontend/src/components/Interaction/index.jsx
+++ b/frontend/src/components/Interaction/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import React, { useEffect, useRef } from 'react';
 import { useData } from '../../utils/Context';
 import { EASE_OUT_CUBIC } from '../../constants';
@@ -13,8 +14,24 @@ import OptionPicker from '../../pages/OptionPickerPage';
 import Estimation from '../../pages/EstimationPage';
 
 function Interaction() {
-  const { page } = useData();
+  const { setTrimState, page } = useData();
   const pageRef = useRef();
+
+  const prevPage = () =>
+    setTrimState((prevState) => ({ ...prevState, page: history.state.nowPage }));
+
+  useEffect(() => {
+    window.addEventListener('popstate', prevPage);
+    return () => {
+      window.removeEventListener('popstate', prevPage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (history.state.nowPage !== page) {
+      history.pushState({ nowPage: page }, '');
+    }
+  }, [page]);
 
   useEffect(() => {
     pageRef.current.style.transition = `all 0.5s ${EASE_OUT_CUBIC}`;

--- a/frontend/src/components/Interaction/index.jsx
+++ b/frontend/src/components/Interaction/index.jsx
@@ -14,29 +14,49 @@ import OptionPicker from '../../pages/OptionPickerPage';
 import Estimation from '../../pages/EstimationPage';
 
 function Interaction() {
-  const { setTrimState, page } = useData();
+  const data = useData();
   const pageRef = useRef();
 
-  const prevPage = () =>
-    setTrimState((prevState) => ({ ...prevState, page: history.state.nowPage }));
-
   useEffect(() => {
-    window.addEventListener('popstate', prevPage);
-    return () => {
-      window.removeEventListener('popstate', prevPage);
+    const handlePopstate = () => {
+      const isFetchMap = {
+        1: data.trim.isFetch,
+        2: data.modelType.isFetch,
+        3: data.exteriorColor.isFetch,
+        4: data.interiorColor.isFetch,
+        5: data.optionPicker.isFetch,
+        6: data.estimation.isFetch,
+      };
+
+      const canGoBack = isFetchMap[history.state.nowPage] || false;
+
+      if (!canGoBack) {
+        const { nowPage } = history.state;
+        if (nowPage !== data.page) {
+          history.replaceState({ nowPage: data.page }, '');
+          return;
+        }
+      }
+      data.setTrimState((prevState) => ({ ...prevState, page: history.state.nowPage }));
     };
-  }, []);
 
-  useEffect(() => {
-    if (history.state.nowPage !== page) {
-      history.pushState({ nowPage: page }, '');
-    }
-  }, [page]);
+    window.addEventListener('popstate', handlePopstate);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopstate);
+    };
+  }, [data]);
 
   useEffect(() => {
     pageRef.current.style.transition = `all 0.5s ${EASE_OUT_CUBIC}`;
-    pageRef.current.style.transform = `translateX(min(-${page - 1}00%, -${(page - 1) * 1280}px))`;
-  }, [page]);
+    pageRef.current.style.transform = `translateX(min(-${data.page - 1}00%, -${
+      (data.page - 1) * 1280
+    }px))`;
+
+    if (history.state.nowPage !== data.page) {
+      history.pushState({ nowPage: data.page }, '');
+    }
+  }, [data.page]);
 
   return (
     <S.Interaction>


### PR DESCRIPTION
## Change
- history로 뒤로가기 이벤트 추가
- isFetch가 false일 경우 뒤로가기 예외처리

isFetch가 false일 경우에는 history를 replace해서 처리함
```js
if (!canGoBack) {
        const { nowPage } = history.state;
        if (nowPage !== data.page) {
          history.replaceState({ nowPage: data.page }, '');
          return;
        }
      }
```

## Issue
- #372 