### PR TITLE
[Backend] 여전히 옵션 또는 패키지가 선택되지 않은 견적서의 유사 견적 개수 조회 시 에러가 발생하는 문제 해결

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/service/SimilarityServiceImpl.java
@@ -123,8 +123,15 @@ public class SimilarityServiceImpl implements SimilarityService {
 
     private List<String> getTotalHashTags(EstimateOptionIdListDto estimateOptionIdListDto) {
         List<String> totalHashTags = new ArrayList<>();
-        totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromOptionsByOptionIds(estimateOptionIdListDto.getOptionIds()));
-        totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromPackagesByPackageIds(estimateOptionIdListDto.getPackageIds()));
+
+        List<Long> optionIds = estimateOptionIdListDto.getOptionIds();
+        if(!optionIds.isEmpty()) {
+            totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromOptionsByOptionIds(optionIds));
+        }
+        List<Long> packageIds = estimateOptionIdListDto.getPackageIds();
+        if (!packageIds.isEmpty()) {
+            totalHashTags.addAll(modelOptionQueryRepository.findHashTagFromPackagesByPackageIds(packageIds));
+        }
         return totalHashTags.stream()
                 .sorted()
                 .collect(Collectors.toList());

--- a/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/QueryString.java
@@ -1,0 +1,4 @@
+package softeer.wantcar.cartalog.similarity.repository;
+
+public class QueryString {
+}


### PR DESCRIPTION
##  한 일
- 옵션 또는 패키지가 선택되지 않은 견적서의 유사 견적 개수 조회 시 에러가 발생하는 문제 해결
    - 이전에는 에러가 발생하는 두 부분 중 한 곳만 수정되었었음