### PR TITLE
[Backend] 유사 견적 조회 API가 실패하는 버그 해결

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryImpl.java
@@ -25,6 +25,9 @@ public class SimilarityQueryRepositoryImpl implements SimilarityQueryRepository 
 
     @Override
     public boolean existHashTagKey(Long trimId, String hashTagKey) {
+        if(hashTagKey.isBlank()) {
+            return true;
+        }
         SqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("trimId", trimId)
                 .addValue("hashTagKey", hashTagKey);

--- a/backend/src/test/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryTest.java
@@ -60,6 +60,17 @@ class SimilarityQueryRepositoryTest {
             //then
             assertThat(response).isFalse();
         }
+
+        @Test
+        @DisplayName("빈 문자열일 경우 true를 반환한다")
+        void returnTrueWhenEmptyString() {
+            //given
+            //when
+            boolean response = similarityQueryRepository.existHashTagKey(1L, "");
+
+            //then
+            assertThat(response).isTrue();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 한 일
- [x] 빈 해시태그가 보류 해시태그 유형 목록에 들어가는 문제 해결
