### PR TITLE
[Front-End] fix: 가격 분포 그래프 오류 해결

### DIFF
--- a/frontend/src/components/PriceGraph/index.jsx
+++ b/frontend/src/components/PriceGraph/index.jsx
@@ -3,7 +3,7 @@ import * as S from './style';
 
 function PriceGraph({ min, max, avg, value, width, height }) {
   const svgRef = useRef();
-  const [coords, setCoords] = useState([]);
+  const [coords, setCoords] = useState([0, 0]);
   const drawWidth = width - 2;
   const drawHeight = height - 2;
   const avgX = ((avg - min) / (max - min)) * width;


### PR DESCRIPTION
# Changes

* 가격 분포 그래프에서  오류 해결 Warning: `NaN` is an invalid value for the `left` css style property. 에러 생기는 문제 해결

# Related Issues

* Close #511 
