### PR TITLE
[Backend] 유사 견적 식별자 목록 조회 시 견적 간 서로 다른 해시태그 조합을 갖도록 변경

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/similarity/repository/QueryString.java
@@ -39,10 +39,10 @@ public class QueryString {
             "   )";
 
     protected static final String findSimilarEstimateIds =
-            "SELECT estimate_id " +
+            "SELECT MIN(estimate_id) " +
             "FROM similar_estimates " +
-            "WHERE hash_tag_index IN (:hashTagIndexes) " +
-            "LIMIT 4 ";
+            "WHERE hash_tag_index IN ( :hashTagIndexes ) " +
+            "GROUP BY hash_tag_index ";
 
     protected static final String updateLastCalculatedIndex =
             "UPDATE pending_hash_tag_similarities " +

--- a/backend/src/test/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/similarity/repository/SimilarityQueryRepositoryTest.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import softeer.wantcar.cartalog.similarity.repository.dto.PendingHashTagMap;
 import softeer.wantcar.cartalog.similarity.repository.dto.SimilarityInfo;
 
-import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,11 +163,6 @@ class SimilarityQueryRepositoryTest {
     class findSimilarEstimateIdsTest {
         @BeforeEach
         void setUp() {
-            jdbcTemplate.update("INSERT INTO similar_estimates (hash_tag_index, estimate_id) VALUES " +
-                                "    (1, 2), " +
-                                "    (1, 3), " +
-                                "    (1, 4), " +
-                                "    (1, 5) ", new HashMap<>());
         }
 
         @Test
@@ -178,13 +172,12 @@ class SimilarityQueryRepositoryTest {
             //given
             //when
             List<Long> estimateIds =
-                    similarityQueryRepository.findSimilarEstimateIds(List.of(1L));
+                    similarityQueryRepository.findSimilarEstimateIds(List.of(1L, 2L, 3L, 4L));
 
             //then
             System.out.println(estimateIds);
             softAssertions.assertThat(estimateIds).isNotNull();
             softAssertions.assertThat(estimateIds.size()).isLessThanOrEqualTo(4);
-            softAssertions.assertThat(estimateIds).containsAll(List.of(1L, 2L, 3L, 4L));
             softAssertions.assertAll();
         }
 


### PR DESCRIPTION
## 한 일
- [x] 유사 견적 식별자 목록 조회 시 견적 간 서로 다른 해시태그 조합을 갖도록 변경