### PR TITLE
[Backend] 클라이언트의 요구사항에 맞게 유사 견적 개수 조회 시 유사 견적의 가격도 같이 제공하도록 변경

### DIFF
--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/EstimateCountInfoDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/dto/EstimateCountInfoDto.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class EstimateCountInfoDto {
     private Long estimateId;
     private Long count;
+    private int price;
     private EstimateResponseDto estimateInfo;
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/QueryString.java
@@ -90,7 +90,8 @@ public class QueryString {
     public static final String findEstimateCounts =
             "SELECT " +
             "   estimate_id, " +
-            "   count(estimate_id) AS count " +
+            "   count(estimate_id) AS count, " +
+            "   (SELECT price FROM estimates WHERE id=estimate_id) AS price " +
             "FROM release_records " +
             "WHERE estimate_id IN (:estimateIds) " +
             "GROUP BY estimate_id ";

--- a/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateCountDto.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/estimate/repository/dto/EstimateCountDto.java
@@ -10,4 +10,5 @@ import lombok.Getter;
 public class EstimateCountDto {
     private Long estimateId;
     private Long count;
+    private int price;
 }

--- a/backend/src/main/java/softeer/wantcar/cartalog/similarity/controller/SimilarityController.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/similarity/controller/SimilarityController.java
@@ -87,6 +87,7 @@ public class SimilarityController {
                 .map(counts -> EstimateCountInfoDto.builder()
                         .estimateId(counts.getEstimateId())
                         .count(counts.getCount())
+                        .price(counts.getPrice())
                         .estimateInfo(estimateService.findEstimateByEstimateId(counts.getEstimateId()))
                         .build()
                 )

--- a/backend/src/main/java/softeer/wantcar/cartalog/similarity/service/SimilarityServiceImpl.java
+++ b/backend/src/main/java/softeer/wantcar/cartalog/similarity/service/SimilarityServiceImpl.java
@@ -169,7 +169,7 @@ public class SimilarityServiceImpl implements SimilarityService {
         return estimateCounts.stream()
                 .filter(estimateCountDto -> Objects.equals(estimateCountDto.getEstimateId(), estimateId))
                 .findAny()
-                .orElse(new EstimateCountDto(estimateId, 0L)).getCount();
+                .orElse(new EstimateCountDto(estimateId, 0L, 40000000)).getCount();
     }
 
     private static List<EstimateCountDto> getSimilarEstimateCounts(Long estimateId, List<EstimateCountDto> estimateCounts) {

--- a/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/estimate/repository/EstimateQueryRepositoryTest.java
@@ -86,8 +86,10 @@ class EstimateQueryRepositoryTest {
             //then
             softAssertions.assertThat(estimateCounts.size()).isEqualTo(3);
             for (int estimateId = 1; estimateId <= estimateCounts.size(); estimateId++) {
-                softAssertions.assertThat(estimateCounts.get(estimateId - 1).getEstimateId())
+                EstimateCountDto curEstimateDto = estimateCounts.get(estimateId - 1);
+                softAssertions.assertThat(curEstimateDto.getEstimateId())
                         .isEqualTo(estimateId);
+                softAssertions.assertThat(curEstimateDto.getPrice()).isGreaterThan(30000000);
             }
             softAssertions.assertAll();
         }

--- a/backend/src/test/java/softeer/wantcar/cartalog/similarity/controller/SimilarityControllerTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/similarity/controller/SimilarityControllerTest.java
@@ -80,8 +80,8 @@ class SimilarityControllerTest {
         void returnStatus200AndEstimateCounts() {
             //given
             SimilarEstimateCountResponseDto expectResponse = new SimilarEstimateCountResponseDto(3L,
-                    List.of(new EstimateCountDto(2L, 3L),
-                            new EstimateCountDto(3L, 4L)));
+                    List.of(new EstimateCountDto(2L, 3L, 40000000),
+                            new EstimateCountDto(3L, 4L, 40000001)));
             when(similarityService.getSimilarEstimateCounts(anyLong()))
                     .thenReturn(expectResponse);
             //when

--- a/backend/src/test/java/softeer/wantcar/cartalog/similarity/service/SimilarityServiceTest.java
+++ b/backend/src/test/java/softeer/wantcar/cartalog/similarity/service/SimilarityServiceTest.java
@@ -104,9 +104,9 @@ class SimilarityServiceTest {
             when(estimateQueryRepository.findEstimateOptionIdsByEstimateId(anyLong()))
                     .thenReturn(new EstimateOptionIdListDto(1L, List.of(1L, 2L), List.of(1L, 2L)));
             when(estimateQueryRepository.findEstimateCounts(anyList()))
-                    .thenReturn(List.of(new EstimateCountDto(1L, 1L),
-                            new EstimateCountDto(2L, 2L),
-                            new EstimateCountDto(3L, 2L)));
+                    .thenReturn(List.of(new EstimateCountDto(1L, 1L, 40000000),
+                            new EstimateCountDto(2L, 2L, 40000001),
+                            new EstimateCountDto(3L, 2L, 40000002)));
             when(similarityQueryRepository.findSimilarEstimateIds(anyList()))
                     .thenReturn(List.of(1L, 2L, 3L));
             //when


### PR DESCRIPTION
## 한 일
- [x] 클라이언트의 요구사항에 맞게 유사 견적 개수 조회 시 유사 견적의 가격도 같이 제공하도록 변경